### PR TITLE
Update the sessionId format to support only unique_id for single node con

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -88,6 +88,9 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     private static final String NODES_REGEX = NODE_REGEX + "(?:(?:\\s+|,)" + NODE_REGEX + ")*";
     private static final Pattern NODES_PATTERN = Pattern.compile( NODES_REGEX );
 
+    private static final String SINGLE_NODE_REGEX = "(([^:]+):([\\d]+))";
+    private static final Pattern SINGLE_NODE_PATTERN = Pattern.compile( SINGLE_NODE_REGEX );
+
     private static final int NODE_AVAILABILITY_CACHE_TTL = 50;
 
     private static final String PROTOCOL_TEXT = "text";
@@ -303,6 +306,8 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         /* init memcached
          */
         final MemcachedConfig config = createMemcachedConfig( _memcachedNodes, _failoverNodes );
+        List<InetSocketAddress> socketAddresses = config.getAddresses();
+
         _memcached = memcachedClient != null ? memcachedClient : createMemcachedClient( config.getNodeIds(), config.getAddresses(),
                 config.getAddress2Ids(), _statistics );
         _nodeIdService = new NodeIdService( createNodeAvailabilityCache( config.getCountNodes(), NODE_AVAILABILITY_CACHE_TTL, _memcached ),
@@ -330,27 +335,35 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     }
 
     protected static MemcachedConfig createMemcachedConfig( final String memcachedNodes, final String failoverNodes ) {
-        if ( !NODES_PATTERN.matcher( memcachedNodes ).matches() ) {
+        if ( !NODES_PATTERN.matcher( memcachedNodes ).matches() && !SINGLE_NODE_PATTERN.matcher(memcachedNodes).matches() ) {
             throw new IllegalArgumentException( "Configured memcachedNodes attribute has wrong format, must match " + NODES_REGEX );
         }
 
         final List<String> nodeIds = new ArrayList<String>();
-        final Matcher matcher = NODE_PATTERN.matcher( memcachedNodes  );
+        final Matcher matcher = NODE_PATTERN.matcher( memcachedNodes);
+
+        final Matcher singleNodeMatcher = SINGLE_NODE_PATTERN.matcher(memcachedNodes);
+
         final List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>();
         final Map<InetSocketAddress, String> address2Ids = new HashMap<InetSocketAddress, String>();
-        while ( matcher.find() ) {
-            initHandleNodeDefinitionMatch( matcher, addresses, address2Ids, nodeIds );
+
+        /**
+         * If mutliple nodes are configured
+         */
+        if (matcher.matches()) {
+            while (matcher.find()) {
+                initHandleNodeDefinitionMatch(matcher, addresses, address2Ids, nodeIds);
+            }
+            if (nodeIds.isEmpty()) {
+                throw new IllegalArgumentException("All nodes are also configured as failover nodes,"
+                        + " this is a configuration failure. In this case, you probably want to leave out the failoverNodes.");
+            }
+        } else if (singleNodeMatcher.matches()) {    //for single 
+            initHandleSingleNodeDefinitionMatch(singleNodeMatcher, addresses);
         }
-
-        final List<String> failoverNodeIds = initFailoverNodes( failoverNodes, nodeIds );
-
-        if ( nodeIds.isEmpty() ) {
-            throw new IllegalArgumentException( "All nodes are also configured as failover nodes,"
-                    + " this is a configuration failure. In this case, you probably want to leave out the failoverNodes." );
-        }
-
+        final List<String> failoverNodeIds = initFailoverNodes(failoverNodes, nodeIds);
         return new MemcachedConfig( memcachedNodes, failoverNodes, new NodeIdList( nodeIds ), failoverNodeIds, addresses, address2Ids );
-    }
+    }                       
 
     private TranscoderService createTranscoderService( final Statistics statistics ) {
         return new TranscoderService( getTranscoderFactory().createTranscoder( this ) );
@@ -422,7 +435,8 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
 
             public boolean isNodeAvailable( final String key ) {
                 try {
-                    memcachedClient.get( _sessionIdFormat.createSessionId( "ping", key ) );
+                    boolean isSingleNode = !_memcachedNodes.contains(" ") && (_failoverNodes== null || _failoverNodes.isEmpty());
+                    memcachedClient.get( _sessionIdFormat.createSessionId( "ping", key, isSingleNode ) );
                     return true;
                 } catch ( final Exception e ) {
                     return false;
@@ -461,6 +475,14 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         address2Ids.put( address, nodeId );
     }
 
+    private static void initHandleSingleNodeDefinitionMatch(final Matcher singleNodeMatcher,
+                                                            final List<InetSocketAddress> addresses) {
+        final String hostname = singleNodeMatcher.group(1);
+        final int port = Integer.parseInt(singleNodeMatcher.group(2));
+        final InetSocketAddress address = new InetSocketAddress(hostname, port);
+        addresses.add(address);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -488,7 +510,9 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
      */
     @Override
     protected synchronized String generateSessionId() {
-        return _sessionIdFormat.createSessionId( super.generateSessionId(), _nodeIdService.getMemcachedNodeId() );
+        boolean isSingleNode = !_memcachedNodes.contains(" ") && (_failoverNodes== null || _failoverNodes.isEmpty());
+        return _sessionIdFormat.createSessionId( super.generateSessionId(), _nodeIdService.getMemcachedNodeId(),
+                isSingleNode);
     }
 
     /**
@@ -730,15 +754,16 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
                     final String nodeId = _sessionIdFormat.extractMemcachedId( session.getId() );
                     final String newNodeId = getNewNodeIdIfUnavailable( nodeId );
                     if ( newNodeId != null ) {
-                        final String newSessionId = _sessionIdFormat.createNewSessionId( session.getId(), newNodeId );
+                        boolean isSingleNode = !_memcachedNodes.contains(" ") && (_failoverNodes== null || _failoverNodes.isEmpty());
+                        final String newSessionId = _sessionIdFormat.createNewSessionId( session.getId(), newNodeId,
+                                isSingleNode);
                         _log.debug( "Session needs to be relocated, setting new id on session..." );
                         session.setIdForRelocate( newSessionId );
                         _statistics.requestWithMemcachedFailover();
                         return newSessionId;
                     }
                 }
-            }
-            else {
+            } else {
 
                 /* for non-sticky sessions we check the validity info
                  */
@@ -794,8 +819,8 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
             session.setSticky( _sticky );
             session.setLastAccessedTimeInternal( validityInfo.getLastAccessedTime() );
             session.setThisAccessedTimeInternal( validityInfo.getThisAccessedTime() );
-
-            final String newSessionId = _sessionIdFormat.createNewSessionId( requestedSessionId, backupNodeId );
+            boolean isSingleNode = !_memcachedNodes.contains(" ") && (_failoverNodes== null || _failoverNodes.isEmpty());
+            final String newSessionId = _sessionIdFormat.createNewSessionId( requestedSessionId, backupNodeId, isSingleNode );
             _log.info( "Session backup loaded from secondary memcached for "+ requestedSessionId +" (will be relocated)," +
             		" setting new id "+ newSessionId +" on session..." );
             session.setIdInternal( newSessionId );

--- a/core/src/main/java/de/javakaffee/web/msm/SessionIdFormat.java
+++ b/core/src/main/java/de/javakaffee/web/msm/SessionIdFormat.java
@@ -55,11 +55,16 @@ public class SessionIdFormat {
      *            the original session id, it might contain the jvm route
      * @param memcachedId
      *            the memcached id to encode in the session id, may be <code>null</code>.
+     * @param isSingleNode
      * @return the sessionId which now contains the memcachedId if one was provided, otherwise
      *  the sessionId unmodified.
-     */
+     */ 
     @Nonnull
-    public String createSessionId( @Nonnull final String sessionId, @Nullable final String memcachedId ) {
+    public String createSessionId(@Nonnull final String sessionId, @Nullable final String memcachedId,
+                                  boolean isSingleNode) {
+        if( isSingleNode ) {
+            return sessionId;
+        }
         if ( LOG.isDebugEnabled() ) {
             LOG.debug( "Creating new session id with orig id '" + sessionId + "' and memcached id '" + memcachedId + "'." );
         }
@@ -86,7 +91,12 @@ public class SessionIdFormat {
      *         former one.
      */
     @Nonnull
-    public String createNewSessionId( @Nonnull final String sessionId, @Nonnull final String newMemcachedId ) {
+    public String createNewSessionId( @Nonnull final String sessionId, @Nonnull final String newMemcachedId,
+                                      final boolean isSingleNode) {
+        if( isSingleNode ) {
+            return sessionId;   
+        }
+
         final int idxDot = sessionId.indexOf( '.' );
         if ( idxDot != -1 ) {
             final String plainSessionId = sessionId.substring( 0, idxDot );

--- a/core/src/test/java/de/javakaffee/web/msm/MemcachedBackupSessionManagerTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/MemcachedBackupSessionManagerTest.java
@@ -65,7 +65,7 @@ public class MemcachedBackupSessionManagerTest {
     public void setup() throws Exception {
 
         _manager = new MemcachedBackupSessionManager();
-        _manager.setMemcachedNodes( "n1:127.0.0.1:11211" );
+        _manager.setMemcachedNodes( "127.0.0.1:11211" );
         _manager.setSessionBackupAsync( false );
         _manager.setSticky( true );
 
@@ -97,7 +97,7 @@ public class MemcachedBackupSessionManagerTest {
 
     @Test
     public void testConfigurationFormatMemcachedNodesFeature44() throws LifecycleException {
-        _manager.setMemcachedNodes( "n1:127.0.0.1:11211" );
+        _manager.setMemcachedNodes( "127.0.0.1:11211" );
         _manager.startInternal(_memcachedMock);
         Assert.assertEquals( _manager.getNodeIds(), Arrays.asList( "n1" ) );
 

--- a/core/src/test/java/de/javakaffee/web/msm/SessionIdFormatTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/SessionIdFormatTest.java
@@ -33,20 +33,20 @@ public class SessionIdFormatTest {
     @Test
     public void testCreateSessionId() {
         final SessionIdFormat cut = new SessionIdFormat();
-        assertEquals( "foo-n", cut.createSessionId( "foo", "n" ) );
-        assertEquals( "foo-n.jvm1", cut.createSessionId( "foo.jvm1", "n" ) );
-        assertEquals( "foo-n.j-v-m1", cut.createSessionId( "foo.j-v-m1", "n" ) );
+        assertEquals( "foo-n", cut.createSessionId( "foo", "n", false) );
+        assertEquals( "foo-n.jvm1", cut.createSessionId( "foo.jvm1", "n", false) );
+        assertEquals( "foo-n.j-v-m1", cut.createSessionId( "foo.j-v-m1", "n", false) );
     }
 
     @Test
     public void testCreateNewSessionId() {
         final SessionIdFormat cut = new SessionIdFormat();
 
-        assertEquals( "foo-n", cut.createNewSessionId( "foo", "n" ) );
-        assertEquals( "foo-m", cut.createNewSessionId( "foo-n", "m" ) );
-        assertEquals( "foo-m.jvm1", cut.createNewSessionId( "foo-n.jvm1", "m" ) );
-        assertEquals( "foo-m.jvm1", cut.createNewSessionId( "foo.jvm1", "m" ) );
-        assertEquals( "foo-m.j-v-m1", cut.createNewSessionId( "foo.j-v-m1", "m" ) );
+        assertEquals( "foo-n", cut.createNewSessionId( "foo", "n", false) );
+        assertEquals( "foo-m", cut.createNewSessionId( "foo-n", "m", false ) );
+        assertEquals( "foo-m.jvm1", cut.createNewSessionId( "foo-n.jvm1", "m", false ) );
+        assertEquals( "foo-m.jvm1", cut.createNewSessionId( "foo.jvm1", "m", false ) );
+        assertEquals( "foo-m.j-v-m1", cut.createNewSessionId( "foo.j-v-m1", "m", false ) );
 
     }
 

--- a/core/src/test/java/de/javakaffee/web/msm/TranscoderServiceTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/TranscoderServiceTest.java
@@ -46,7 +46,7 @@ public class TranscoderServiceTest {
     public static void setup() throws LifecycleException {
 
         _manager = new MemcachedBackupSessionManager();
-        _manager.setMemcachedNodes( "n1:127.0.0.1:11211" );
+        _manager.setMemcachedNodes( "127.0.0.1:11211" );
 
         final StandardContext container = new StandardContext();
         container.setPath( "/" );


### PR DESCRIPTION
Update the sessionId format to support only unique_id for single node configurationfor single node configurations.
Update the manager configuration to support sessionId with unique_id format without nodeId, when single node is configured.
