### PR TITLE
Fix Tomcat dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,25 +18,25 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>catalina</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>catalina-ha</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>coyote</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>spy</groupId>

--- a/flexjson-serializer/pom.xml
+++ b/flexjson-serializer/pom.xml
@@ -25,6 +25,24 @@
 			<version>2.1</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>juli</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- use msm core test classes in tests -->
 		<!-- see http://maven.apache.org/guides/mini/guide-attached-tests.htmlf -->
@@ -35,11 +53,11 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>de.javakaffee.msm</groupId>
-            <artifactId>memcached-session-manager-tc7</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>de.javakaffee.msm</groupId>
+			<artifactId>memcached-session-manager-tc7</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/javolution-serializer/pom.xml
+++ b/javolution-serializer/pom.xml
@@ -20,6 +20,24 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>juli</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket</artifactId>
 			<version>1.4.17</version>

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -25,6 +25,24 @@
 			<version>0.10</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>juli</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket</artifactId>
 			<version>1.4.17</version>

--- a/serializer-benchmark/pom.xml
+++ b/serializer-benchmark/pom.xml
@@ -18,6 +18,24 @@
 			<artifactId>memcached-session-manager</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>juli</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
         <dependency>
             <groupId>de.javakaffee.msm</groupId>
             <artifactId>memcached-session-manager-tc7</artifactId>

--- a/tomcat6/pom.xml
+++ b/tomcat6/pom.xml
@@ -14,21 +14,45 @@
 	<description>The msm tomcat6 specific implementation.</description>
 
 	<dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>memcached-session-manager</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>memcached-session-manager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.5</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina-ha</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <!-- use msm core test classes in tests -->
-        <!-- see http://maven.apache.org/guides/mini/guide-attached-tests.htmlf -->
-        <dependency>
-            <groupId>de.javakaffee.msm</groupId>
-            <artifactId>memcached-session-manager</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
+		<!-- use msm core test classes in tests -->
+		<!-- see http://maven.apache.org/guides/mini/guide-attached-tests.htmlf -->
+		<dependency>
+			<groupId>de.javakaffee.msm</groupId>
+			<artifactId>memcached-session-manager</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.couchbase.mock</groupId>
 			<artifactId>CouchbaseMock</artifactId>

--- a/tomcat7/pom.xml
+++ b/tomcat7/pom.xml
@@ -18,85 +18,50 @@
 	</properties>
 
 	<dependencies>
-	    <dependency>
-	        <groupId>${project.groupId}</groupId>
-	        <artifactId>memcached-session-manager</artifactId>
-	        <version>${project.version}</version>
-	        <exclusions>
-               <exclusion>
-                   <groupId>javax.servlet</groupId>
-                   <artifactId>servlet-api</artifactId>
-               </exclusion>
-	           <exclusion>
-	               <groupId>org.apache.tomcat</groupId>
-                   <artifactId>catalina</artifactId>
-               </exclusion>
-               <exclusion>
-                   <groupId>org.apache.tomcat</groupId>
-                   <artifactId>catalina-ha</artifactId>
-               </exclusion>
-               <exclusion>
-                   <groupId>org.apache.tomcat</groupId>
-                   <artifactId>coyote</artifactId>
-               </exclusion>
-	        </exclusions>
-	    </dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>memcached-session-manager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
-        <!-- use msm core test classes in tests -->
-        <!-- see http://maven.apache.org/guides/mini/guide-attached-tests.htmlf -->
-        <dependency>
-            <groupId>de.javakaffee.msm</groupId>
-            <artifactId>memcached-session-manager</artifactId>
-            <version>${project.version}</version>
-			<!-- use classifier:tests, as type:test-jar creates a wrong classpath, 
-				see http://jira.codehaus.org/browse/MNG-5096 -->
-			<classifier>tests</classifier>
-            <scope>test</scope>
-            <exclusions>
-               <exclusion>
-                   <groupId>javax.servlet</groupId>
-                   <artifactId>servlet-api</artifactId>
-               </exclusion>
-               <exclusion>
-                   <groupId>org.apache.tomcat</groupId>
-                   <artifactId>catalina</artifactId>
-               </exclusion>
-               <exclusion>
-                   <groupId>org.apache.tomcat</groupId>
-                   <artifactId>catalina-ha</artifactId>
-               </exclusion>
-               <exclusion>
-                   <groupId>org.apache.tomcat</groupId>
-                   <artifactId>coyote</artifactId>
-               </exclusion>
-            </exclusions>
-        </dependency>
-	    
+		<!-- Tomcat dependencies -->
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-servlet-api</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-catalina</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-catalina-ha</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-coyote</artifactId>
 			<version>${tomcat-version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
-		
+
+		<!-- use msm core test classes in tests -->
+		<!-- see http://maven.apache.org/guides/mini/guide-attached-tests.htmlf -->
+		<dependency>
+			<groupId>de.javakaffee.msm</groupId>
+			<artifactId>memcached-session-manager</artifactId>
+			<version>${project.version}</version>
+			<!-- use classifier:tests, as type:test-jar creates a wrong classpath,
+			     see http://jira.codehaus.org/browse/MNG-5096 -->
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+		<!-- Mocks -->
 		<dependency>
 			<groupId>org.couchbase.mock</groupId>
 			<artifactId>CouchbaseMock</artifactId>
@@ -110,7 +75,5 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
-
 </project>

--- a/xstream-serializer/pom.xml
+++ b/xstream-serializer/pom.xml
@@ -20,6 +20,24 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>juli</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>coyote</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>catalina</artifactId>
+			<version>${tomcat-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.4.2</version>


### PR DESCRIPTION
In the current state Tomcat dependencies are being forced into WAR archives which causes a number of unexpected and undesired effects. All this is caused by <scope>compile</scope> scope with org.apache.tomcat:\* dependencies.

This fix utilizes the <scope>provided</scope> scope where appropriate to fix that.
