### PR TITLE
Fixed problem with detecting session ID if response contains multiple Set-Cookie headers.

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
+++ b/core/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
@@ -240,19 +240,23 @@ public class RequestTrackingHostValve extends ValveBase {
     }
 
     private String getSessionIdFromResponseSessionCookie( final Response response ) {
-        final String header = response.getHeader( "Set-Cookie" );
-        if ( header != null && header.contains( _sessionCookieName ) ) {
-            final String sessionIdPrefix = _sessionCookieName + "=";
-            final int idxNameStart = header.indexOf( sessionIdPrefix );
-            final int idxValueStart = idxNameStart + sessionIdPrefix.length();
-            int idxValueEnd = header.indexOf( ';', idxNameStart );
-            if ( idxValueEnd == -1 ) {
-                idxValueEnd = header.indexOf( ' ', idxValueStart );
+        final String[] headers = response.getHeaderValues( "Set-Cookie" );
+        if( headers != null ) {
+            for( final String header : headers ) {
+                if ( header != null && header.contains( _sessionCookieName ) ) {
+                    final String sessionIdPrefix = _sessionCookieName + "=";
+                    final int idxNameStart = header.indexOf( sessionIdPrefix );
+                    final int idxValueStart = idxNameStart + sessionIdPrefix.length();
+                    int idxValueEnd = header.indexOf( ';', idxNameStart );
+                    if ( idxValueEnd == -1 ) {
+                        idxValueEnd = header.indexOf( ' ', idxValueStart );
+                    }
+                    if ( idxValueEnd == -1 ) {
+                        idxValueEnd = header.length();
+                    }
+                    return header.substring( idxValueStart, idxValueEnd );
+                }
             }
-            if ( idxValueEnd == -1 ) {
-                idxValueEnd = header.length();
-            }
-            return header.substring( idxValueStart, idxValueEnd );
         }
         return null;
     }

--- a/core/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveTest.java
@@ -98,7 +98,7 @@ public class RequestTrackingHostValveTest {
     @Test
     public final void testBackupSessionNotInvokedWhenNoSessionIdPresent() throws IOException, ServletException {
         when( _request.getRequestedSessionId() ).thenReturn( null );
-        when( _response.getHeader( eq( "Set-Cookie" ) ) ).thenReturn( null );
+        when( _response.getHeaderValues( eq( "Set-Cookie" ) ) ).thenReturn( null );
 
         _sessionTrackerValve.invoke( _request, _response );
 
@@ -109,7 +109,7 @@ public class RequestTrackingHostValveTest {
     public final void testBackupSessionInvokedWhenResponseCookiePresent() throws IOException, ServletException {
         when( _request.getRequestedSessionId() ).thenReturn( null );
         final Cookie cookie = new Cookie( _sessionTrackerValve.getSessionCookieName(), "foo" );
-        when( _response.getHeader( eq( "Set-Cookie" ) ) ).thenReturn( generateCookieString( cookie ) );
+        when( _response.getHeaderValues( eq( "Set-Cookie" ) ) ).thenReturn( new String[] { generateCookieString( cookie ) } );
         _sessionTrackerValve.invoke( _request, _response );
 
         verify( _service ).backupSession( eq( "foo" ), eq( false), anyString() );
@@ -136,7 +136,7 @@ public class RequestTrackingHostValveTest {
         when( _request.getRequestedSessionId() ).thenReturn( sessionId );
 
         final Cookie cookie = new Cookie( _sessionTrackerValve.getSessionCookieName(), newSessionId );
-        when( _response.getHeader( eq( "Set-Cookie" ) ) ).thenReturn( generateCookieString( cookie ) );
+        when( _response.getHeaderValues( eq( "Set-Cookie" ) ) ).thenReturn( new String[] { generateCookieString( cookie ) } );
 
         _sessionTrackerValve.invoke( _request, _response );
 


### PR DESCRIPTION
One of our customers ran into a problem when using memcached-session-manager in their application. After some debugging, we saw that one of our filters added a Set-Cookie header for our own cookie before Tomcat could add its Set-Cookie header for JSESSIONID. 

We think that memcached-session-manager should check all Set-Cookie response headers instead of only the first one in method RequestTrackingHostValve::getSessionIdFromResponseSessionCookie. 
