### PR TITLE
Fixed problem with detecting session ID if response contains multiple Set-Cookie headers.

### DIFF
--- a/tomcat6/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT6Test.java
+++ b/tomcat6/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT6Test.java
@@ -1,0 +1,16 @@
+package de.javakaffee.web.msm;
+
+import org.apache.catalina.connector.Response;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@Test
+public class RequestTrackingHostValveT6Test extends RequestTrackingHostValveTest {
+
+    @Override
+    protected void setupGetResponseSetCookieHeadersExpectations(Response response, String[] result) {
+        when(response.getHeaderValues(eq("Set-Cookie"))).thenReturn(result);
+    }
+}

--- a/tomcat7/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT7Test.java
+++ b/tomcat7/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT7Test.java
@@ -1,0 +1,18 @@
+package de.javakaffee.web.msm;
+
+import org.apache.catalina.connector.Response;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@Test
+public class RequestTrackingHostValveT7Test extends RequestTrackingHostValveTest {
+
+    @Override
+    protected void setupGetResponseSetCookieHeadersExpectations(Response response, String[] result) {
+        when(response.getHeaders(eq("Set-Cookie"))).thenReturn(Arrays.asList(result));
+    }
+}


### PR DESCRIPTION
This patch is very similar to https://github.com/magro/memcached-session-manager/pull/21

The difference is that this patch works with both Tomcat6 and 7. If you look at org.apache.catalina.connector.Response, the getHeaderValues() method was replaced with getHeaders() in Tomcat7. 

The reason for the patch is the same. Quoting from the other pull request:

> One of our customers ran into a problem when using memcached-session-manager in their application. After some debugging, we saw that one of our filters added a Set-Cookie header for our own cookie before Tomcat could add its Set-Cookie header for JSESSIONID.
> 
> We think that memcached-session-manager should check all Set-Cookie response headers instead of only the first one in method RequestTrackingHostValve::getSessionIdFromResponseSessionCookie.
