### PR TITLE
support multiple couchbase configuration nodes

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -1536,7 +1536,7 @@ public class MemcachedSessionService {
         if ( lockingMode == null ) {
             lockingMode = LockingMode.NONE;
         }
-        final boolean storeSecondaryBackup = config.getCountNodes() > 1;
+        final boolean storeSecondaryBackup = config.getCountNodes() > 1 && !config.isCouchbaseBucketConfig();
         setLockingMode( lockingMode, uriPattern, storeSecondaryBackup );
     }
 


### PR DESCRIPTION
it is (technically) possible to have multiple configuration nodes (through CouchbaseClient(List< URI >...). this is important on restarting a tomcat while the main configuration node is down.

memcachedNodes="http://1.2.3.4:8091/pools http://1.2.3.5:8091/pools http://1.2.3.6:8091/pools"

on a couchbase installation there should be no backup of the session, since the replication is handled by the couchbase instances itself.
