### PR TITLE
Without Couchbase Client lib deployment not working!

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/CouchbaseClientFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/CouchbaseClientFactory.java
@@ -27,6 +27,8 @@ import com.couchbase.client.CouchbaseConnectionFactoryBuilder;
  */
 public class CouchbaseClientFactory {
 
+    public CouchbaseClientFactory () {}
+
     protected CouchbaseClient createCouchbaseClient(final MemcachedNodesManager memcachedNodesManager,
             final String memcachedProtocol, final String username, String password, final long operationTimeout,
             final Statistics statistics ) {


### PR DESCRIPTION
After testing without couch base client libs, see that static class loader depend not gone.
# 

org.apache.catalina.LifecycleException: Failed to start component [de.javakaffee.web.msm.MemcachedBackupSessionManager[/ClusterMCTest]]
       at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:154)
       at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5443)
       at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
       at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:901)
       at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:877)
       at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:633)
       at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:976)
       at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1653)
       at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
       at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
       at java.util.concurrent.FutureTask.run(FutureTask.java:166)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
       at java.lang.Thread.run(Thread.java:722)
Caused by: java.lang.NoClassDefFoundError: com/couchbase/client/CouchbaseClient
       at de.javakaffee.web.msm.MemcachedSessionService.createMemcachedClient(MemcachedSessionService.java:466)
       at de.javakaffee.web.msm.MemcachedSessionService.startInternal(MemcachedSessionService.java:399)
       at de.javakaffee.web.msm.MemcachedBackupSessionManager.startInternal(MemcachedBackupSessionManager.java:522)
       at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
# :

FIX: Use Refelct API
Now I use reflect API to call CouchbaseClientFactory and it works!
