### PR TITLE
host valve should support atleast the async attribute for tc7

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/LockingStrategyAuto.java
+++ b/core/src/main/java/de/javakaffee/web/msm/LockingStrategyAuto.java
@@ -127,9 +127,9 @@ public class LockingStrategyAuto extends LockingStrategy {
 
         /* lets see if we can skip the locking as we consider this beeing a readonly request
          */
-        if ( _readOnlyRequestCache.isReadOnlyRequest( RequestTrackingHostValve.getURIWithQueryString( request ) ) ) {
+        if ( _readOnlyRequestCache.isReadOnlyRequest( AbstractRequestTrackingHostValve.getURIWithQueryString( request ) ) ) {
             if ( _log.isDebugEnabled() ) {
-                _log.debug( "Not getting lock for readonly request " + RequestTrackingHostValve.getURIWithQueryString( request ) );
+                _log.debug( "Not getting lock for readonly request " + AbstractRequestTrackingHostValve.getURIWithQueryString( request ) );
             }
             _stats.nonStickySessionsReadOnlyRequest();
             return LockStatus.LOCK_NOT_REQUIRED;

--- a/core/src/main/java/de/javakaffee/web/msm/LockingStrategyUriPattern.java
+++ b/core/src/main/java/de/javakaffee/web/msm/LockingStrategyUriPattern.java
@@ -64,15 +64,15 @@ public class LockingStrategyUriPattern extends LockingStrategy {
 
         /* let's see if we should lock the session for this request
          */
-        if ( _uriPattern.matcher( RequestTrackingHostValve.getURIWithQueryString( request ) ).matches() ) {
+        if ( _uriPattern.matcher( AbstractRequestTrackingHostValve.getURIWithQueryString( request ) ).matches() ) {
             if ( _log.isDebugEnabled() ) {
-                _log.debug( "Lock request for request " + RequestTrackingHostValve.getURIWithQueryString( request ) );
+                _log.debug( "Lock request for request " + AbstractRequestTrackingHostValve.getURIWithQueryString( request ) );
             }
             return lock( sessionId );
         }
 
         if ( _log.isDebugEnabled() ) {
-        	_log.debug( "Not lock request for request " + RequestTrackingHostValve.getURIWithQueryString( request ) );
+        	_log.debug( "Not lock request for request " + AbstractRequestTrackingHostValve.getURIWithQueryString( request ) );
         }
 
         _stats.nonStickySessionsReadOnlyRequest();

--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -266,7 +266,7 @@ public class MemcachedSessionService {
     private long _operationTimeout = 1000;
 
     private CurrentRequest _currentRequest;
-    private RequestTrackingHostValve _trackingHostValve;
+    private AbstractRequestTrackingHostValve _trackingHostValve;
     private RequestTrackingContextValve _trackingContextValve;
 
     private Boolean _contextHasFormBasedSecurityConstraint;
@@ -394,6 +394,10 @@ public class MemcachedSessionService {
          */
         @Nonnull
         MemcachedBackupSession newMemcachedBackupSession();
+
+        @Nonnull
+        AbstractRequestTrackingHostValve createRequestTrackingHostValve(@Nullable final String ignorePattern, @Nonnull final String sessionCookieName,
+                @Nonnull final MemcachedSessionService sessionBackupService, @Nonnull final Statistics statistics, @Nonnull final AtomicBoolean enabled, @Nonnull final CurrentRequest currentRequest);
     }
 
     public void shutdown() {
@@ -444,7 +448,7 @@ public class MemcachedSessionService {
 
         final String sessionCookieName = _manager.getSessionCookieName();
         _currentRequest = new CurrentRequest();
-        _trackingHostValve = new RequestTrackingHostValve(_requestUriIgnorePattern, sessionCookieName, this, _statistics, _enabled, _currentRequest);
+        _trackingHostValve = _manager.createRequestTrackingHostValve(_requestUriIgnorePattern, sessionCookieName, this, _statistics, _enabled, _currentRequest);
         _manager.getContainer().getParent().getPipeline().addValve(_trackingHostValve);
         _trackingContextValve = new RequestTrackingContextValve(sessionCookieName, this);
         _manager.getContainer().getPipeline().addValve( _trackingContextValve );
@@ -1718,7 +1722,7 @@ public class MemcachedSessionService {
         _memcached = memcachedClient;
     }
 
-    RequestTrackingHostValve getTrackingHostValve() {
+    AbstractRequestTrackingHostValve getTrackingHostValve() {
         return _trackingHostValve;
     }
 

--- a/core/src/main/java/de/javakaffee/web/msm/RequestTrackingContextValve.java
+++ b/core/src/main/java/de/javakaffee/web/msm/RequestTrackingContextValve.java
@@ -40,7 +40,7 @@ public class RequestTrackingContextValve extends ValveBase {
     static final String INVOKED = "de.javakaffee.msm.contextValve.invoked";
     static final String RELOCATE = "session.relocate";
 
-    protected static final Log _log = LogFactory.getLog( RequestTrackingHostValve.class );
+    protected static final Log _log = LogFactory.getLog( AbstractRequestTrackingHostValve.class );
 
     private final MemcachedSessionService _sessionBackupService;
     protected final String _sessionCookieName;
@@ -81,13 +81,13 @@ public class RequestTrackingContextValve extends ValveBase {
     @Override
     public void invoke( final Request request, final Response response ) throws IOException, ServletException {
 
-        final Object processRequest = request.getNote(RequestTrackingHostValve.REQUEST_PROCESS);
+        final Object processRequest = request.getNote(AbstractRequestTrackingHostValve.REQUEST_PROCESS);
         if(processRequest != Boolean.TRUE) {
             request.setNote(INVOKED, Boolean.TRUE);
             try {
                 getNext().invoke( request, response );
             } finally {
-                request.setNote(RequestTrackingHostValve.REQUEST_PROCESSED, Boolean.TRUE);
+                request.setNote(AbstractRequestTrackingHostValve.REQUEST_PROCESSED, Boolean.TRUE);
             }
         }
         else {
@@ -98,8 +98,8 @@ public class RequestTrackingContextValve extends ValveBase {
                 sessionIdChanged = changeRequestedSessionId( request, response );
                 getNext().invoke( request, response );
             } finally {
-                request.setNote(RequestTrackingHostValve.REQUEST_PROCESSED, Boolean.TRUE);
-                request.setNote(RequestTrackingHostValve.SESSION_ID_CHANGED, Boolean.valueOf(sessionIdChanged));
+                request.setNote(AbstractRequestTrackingHostValve.REQUEST_PROCESSED, Boolean.TRUE);
+                request.setNote(AbstractRequestTrackingHostValve.SESSION_ID_CHANGED, Boolean.valueOf(sessionIdChanged));
             }
 
         }

--- a/core/src/test/java/de/javakaffee/web/msm/RequestTrackingContextValveTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/RequestTrackingContextValveTest.java
@@ -58,7 +58,7 @@ public class RequestTrackingContextValveTest {
         _request = mock( Request.class );
         _response = mock( Response.class );
 
-        when(_request.getNote(eq(RequestTrackingHostValve.REQUEST_PROCESS))).thenReturn(Boolean.TRUE);
+        when(_request.getNote(eq(AbstractRequestTrackingHostValve.REQUEST_PROCESS))).thenReturn(Boolean.TRUE);
     }
 
     @Nonnull
@@ -83,7 +83,7 @@ public class RequestTrackingContextValveTest {
     @Test
     public final void testRequestIsMarkedAsProcessed() throws IOException, ServletException {
         _sessionTrackerValve.invoke( _request, _response );
-        verify(_request).setNote(eq(RequestTrackingHostValve.REQUEST_PROCESSED), eq(Boolean.TRUE));
+        verify(_request).setNote(eq(AbstractRequestTrackingHostValve.REQUEST_PROCESSED), eq(Boolean.TRUE));
     }
 
     @Test
@@ -98,7 +98,7 @@ public class RequestTrackingContextValveTest {
         _sessionTrackerValve.invoke( _request, _response );
 
         verify( _request ).changeSessionId( eq( newSessionId ) );
-        verify(_request).setNote(eq(RequestTrackingHostValve.SESSION_ID_CHANGED), eq(Boolean.TRUE));
+        verify(_request).setNote(eq(AbstractRequestTrackingHostValve.SESSION_ID_CHANGED), eq(Boolean.TRUE));
 
     }
 

--- a/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -50,6 +50,7 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 
 import de.javakaffee.web.msm.LockingStrategy.LockingMode;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This {@link Manager} stores session in configured memcached nodes after the
@@ -1049,4 +1050,8 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return _msm;
     }
 
+    @Override
+    public AbstractRequestTrackingHostValve createRequestTrackingHostValve(String ignorePattern, String sessionCookieName, MemcachedSessionService sessionBackupService, Statistics statistics, AtomicBoolean enabled, CurrentRequest currentRequest) {
+        return new RequestTrackingHostValve(ignorePattern, sessionCookieName, sessionBackupService, statistics, enabled, currentRequest);
+    }
 }

--- a/tomcat6/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
+++ b/tomcat6/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013 Hans-Joachim Kliemeck.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.javakaffee.web.msm;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.catalina.connector.Response;
+
+/**
+ *
+ * @author Hans-Joachim Kliemeck
+ */
+public class RequestTrackingHostValve extends AbstractRequestTrackingHostValve {
+    public RequestTrackingHostValve(String ignorePattern, String sessionCookieName, MemcachedSessionService sessionBackupService, Statistics statistics, AtomicBoolean enabled, CurrentRequest currentRequest) {
+        super(ignorePattern, sessionCookieName, sessionBackupService, statistics, enabled, currentRequest);
+    }
+
+    protected String[] getResponseSetCookieHeaders(final Response response) {
+        return response.getHeaderValues("Set-Cookie");
+    }
+}

--- a/tomcat6/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT6Test.java
+++ b/tomcat6/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT6Test.java
@@ -1,5 +1,6 @@
 package de.javakaffee.web.msm;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.catalina.connector.Response;
 import org.testng.annotations.Test;
 
@@ -12,5 +13,11 @@ public class RequestTrackingHostValveT6Test extends RequestTrackingHostValveTest
     @Override
     protected void setupGetResponseSetCookieHeadersExpectations(Response response, String[] result) {
         when(response.getHeaderValues(eq("Set-Cookie"))).thenReturn(result);
+    }
+
+    @Override
+    protected AbstractRequestTrackingHostValve createSessionTrackerValve() {
+        return new RequestTrackingHostValve(".*\\.(png|gif|jpg|css|js|ico)$", "somesessionid", _service, Statistics.create(),
+                new AtomicBoolean( true ), new CurrentRequest());
     }
 }

--- a/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -46,6 +46,7 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 
 import de.javakaffee.web.msm.LockingStrategy.LockingMode;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This {@link Manager} stores session in configured memcached nodes after the
@@ -859,4 +860,8 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return _msm;
     }
 
+    @Override
+    public AbstractRequestTrackingHostValve createRequestTrackingHostValve(String ignorePattern, String sessionCookieName, MemcachedSessionService sessionBackupService, Statistics statistics, AtomicBoolean enabled, CurrentRequest currentRequest) {
+        return new RequestTrackingHostValve(ignorePattern, sessionCookieName, sessionBackupService, statistics, enabled, currentRequest);
+    }
 }

--- a/tomcat7/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 Hans-Joachim Kliemeck.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.javakaffee.web.msm;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.catalina.connector.Response;
+
+/**
+ *
+ * @author Hans-Joachim Kliemeck
+ */
+public class RequestTrackingHostValve extends AbstractRequestTrackingHostValve {
+    public RequestTrackingHostValve(String ignorePattern, String sessionCookieName, MemcachedSessionService sessionBackupService, Statistics statistics, AtomicBoolean enabled, CurrentRequest currentRequest) {
+        super(ignorePattern, sessionCookieName, sessionBackupService, statistics, enabled, currentRequest);
+        
+        // enable async since host valve is used by all applications
+        setAsyncSupported(true);
+    }
+
+    protected String[] getResponseSetCookieHeaders(final Response response) {
+        Collection<String> result = response.getHeaders("Set-Cookie");
+        return result.toArray(new String[result.size()]);
+    }
+}

--- a/tomcat7/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT7Test.java
+++ b/tomcat7/src/test/java/de/javakaffee/web/msm/RequestTrackingHostValveT7Test.java
@@ -4,6 +4,7 @@ import org.apache.catalina.connector.Response;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
@@ -14,5 +15,11 @@ public class RequestTrackingHostValveT7Test extends RequestTrackingHostValveTest
     @Override
     protected void setupGetResponseSetCookieHeadersExpectations(Response response, String[] result) {
         when(response.getHeaders(eq("Set-Cookie"))).thenReturn(Arrays.asList(result));
+    }
+
+    @Override
+    protected AbstractRequestTrackingHostValve createSessionTrackerValve() {
+        return new RequestTrackingHostValve(".*\\.(png|gif|jpg|css|js|ico)$", "somesessionid", _service, Statistics.create(),
+                new AtomicBoolean( true ), new CurrentRequest());
     }
 }


### PR DESCRIPTION
since tc7 will go through all valves and check for async compatibility, the host valve should support atleast the async attribute since it is used globally on all applications regardless if they use msm. in addition moved dirty hack on getResponseSetCookieHeaders to specific subclass too
