### PR TITLE
Factory class for use with the tomcat-maven-plugin standalone war functionality

### DIFF
--- a/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManagerFactory.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManagerFactory.java
@@ -1,11 +1,14 @@
 package de.javakaffee.web.msm;
 
 import org.apache.catalina.Manager;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
 
 import de.javakaffee.web.msm.MemcachedSessionService.SessionManager;
 
 public class MemcachedBackupSessionManagerFactory {
-
+    private static final Log LOG = LogFactory.getLog( MemcachedBackupSessionManagerFactory.class );
+    
     private static final String DEFAULT_TRANSCODER_FACTORY = JavaSerializationTranscoderFactory.class.getName();
     
     public Manager createSessionManager() {
@@ -45,7 +48,7 @@ public class MemcachedBackupSessionManagerFactory {
         sessionManager.getMemcachedSessionService().setTranscoderFactoryClass( transcoderFactoryClassName);
         sessionManager.getMemcachedSessionService().setRequestUriIgnorePattern(requestUriIgnorePattern);
 
-        System.out.println("MemcachedBackupSessionManager constructed");
+        LOG.info("MemcachedBackupSessionManager constructed");
         return sessionManager;
     }
 }


### PR DESCRIPTION
This factory can be called from the tomcat standalone bootstrap code to use memcached-session-manager within your standalone project. I only implemented it for TC7 because the standalone war support is only for that version of tomcat. When using this factory, you configure msm with system properties. I could imagine this being improved with models.

Using this patch, in conjunction with a matching tomcat-maven-plugin patch, you can start your standalone project like this:

```
java -Dmsm.memcachedNodes="n1:localhost:21211" -jar standalone.jar \
   -sessionManagerFactory de.javakaffee.web.msm.MemcachedBackupSessionManagerFactory
```

The tomcat-maven-plugin pull request can be found here:

https://github.com/apache/tomcat-maven-plugin/pull/5
