### PR TITLE
#284 remove new session id from  _invalidSessionsCache

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -696,7 +696,13 @@ public class MemcachedSessionService {
         }
 
         _manager.incrementSessionCounter();
-
+        //if the new session exist in _invalidSessionsCache, we should remove it marking this session valid.(#284)
+        if( _invalidSessionsCache.get(session.getId()) ){
+            if ( _log.isDebugEnabled() ) {
+                _log.debug( "Remove session id  " + session.getId() + "  from _invalidSessionsCache, marking new session valid" );
+            }
+            _invalidSessionsCache.remove(session.getId());            
+        }
         return session;
 
     }

--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -697,7 +697,7 @@ public class MemcachedSessionService {
 
         _manager.incrementSessionCounter();
         //if the new session exist in _invalidSessionsCache, we should remove it marking this session valid.(#284)
-        if( _invalidSessionsCache.get(session.getId()) ){
+        if( _invalidSessionsCache.containsKey(session.getId()) ){
             if ( _log.isDebugEnabled() ) {
                 _log.debug( "Remove session id  " + session.getId() + "  from _invalidSessionsCache, marking new session valid" );
             }


### PR DESCRIPTION
if the new session exist in _invalidSessionsCache, we should remove it marking this session valid.

After fix it. Without changing my test script and application I provide in #284,  it  work successful !

the shell output:
```
alvisqindeMacBook-Pro:Desktop alvisqin$ ./sessiontest.sh 
assume: The getSigninForm request return sessioncookie: JSESSIONID=42D24D10BD954F66552649AE54FB86D2-n1'
So i will post my request with JSESSIONID=42D24D10BD954F66552649AE54FB86D2-n1
here we go
2016年 1月23日 星期六 22时58分04秒 CST----- postSigninForm
loginSuccess
2016年 1月23日 星期六 22时58分05秒 CST----- afterLogin
your profile info is:{name:alvis, balance:$10000 }
Another case: I will post signin request and sleep 5 second.Then the afterLogin request can success get session 
here we go
assume: The getSigninForm request return sessioncookie: JSESSIONID=42D24D10BD954F66552649AE54FB86D2-n1'
2016年 1月23日 星期六 22时58分05秒 CST----- postSigninForm
loginSuccess
sleep 5 second
2016年 1月23日 星期六 22时58分10秒 CST----- afterLogin## had slept 5 second
your profile info is:{name:alvis, balance:$10000 }

```

tomcat log:
```
一月 23, 2016 10:58:04 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: >>>>>> Request starting: GET /testWeb/tss?state=postSigninForm (requestedSessionId 42D24D10BD954F66552649AE54FB86D2-n1) ==================
一月 23, 2016 10:58:04 下午 de.javakaffee.web.msm.SessionIdFormat createSessionId
详细: Creating new session id with orig id 'ping' and memcached id 'n1'.
一月 23, 2016 10:58:04 下午 de.javakaffee.web.msm.NodeAvailabilityCache updateIsNodeAvailable
详细: CacheLoader returned node availability 'true' for node 'n1'.
-----    user login   -----
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Loading session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Found session with id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedBackupSessionManager removeInternal
详细: remove invoked, removeFromMemcached: true, id: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService deleteFromMemcached
详细: Deleting session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
bind only one attribute to my new session
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: createSession invoked: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: Created new session with id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: remove session id 42D24D10BD954F66552649AE54FB86D2-n1from _invalidSessionsCache
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionService backupSession
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.LockingStrategy onAfterBackupSession
详细: Stored session validity info for session 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask doBackupSession
详细: Trying to store session in memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugRequestSessionCookie
详细: Have request session cookie: domain=null, maxAge=-1, path=null, value=42D24D10BD954F66552649AE54FB86D2-n1, version=0, secure=false
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Finished for session id 42D24D10BD954F66552649AE54FB86D2-n1, returning status SUCCESS
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugResponseCookie
详细: Request finished, with Set-Cookie header: JSESSIONID=42D24D10BD954F66552649AE54FB86D2-n1; Path=/; HttpOnly
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: <<<<<< Request finished: GET /testWeb/tss?state=postSigninForm ==================
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: >>>>>> Request starting: GET /testWeb/tss?state=afterLogin (requestedSessionId 42D24D10BD954F66552649AE54FB86D2-n1) ==================
-----    afterLogin   -----
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Loading session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Found session with id 42D24D10BD954F66552649AE54FB86D2-n1
you profile is: {name:alvis, balance:$10000 }
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionService backupSession
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.LockingStrategy onAfterBackupSession
详细: Stored session validity info for session 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Finished for session id 42D24D10BD954F66552649AE54FB86D2-n1, returning status SKIPPED
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugRequestSessionCookie
详细: Have request session cookie: domain=null, maxAge=-1, path=null, value=42D24D10BD954F66552649AE54FB86D2-n1, version=0, secure=false
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: <<<<<< Request finished: GET /testWeb/tss?state=afterLogin ==================
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: >>>>>> Request starting: GET /testWeb/tss?state=postSigninForm (requestedSessionId 42D24D10BD954F66552649AE54FB86D2-n1) ==================
-----    user login   -----
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Loading session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.LockingStrategy pingSession
详细: The session was ping'ed successfully.
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Found session with id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedBackupSessionManager removeInternal
详细: remove invoked, removeFromMemcached: true, id: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService deleteFromMemcached
详细: Deleting session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
bind only one attribute to my new session
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: createSession invoked: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: Created new session with id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.MemcachedSessionService createSession
详细: remove session id 42D24D10BD954F66552649AE54FB86D2-n1from _invalidSessionsCache
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionService backupSession
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.LockingStrategy onAfterBackupSession
详细: Stored session validity info for session 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugRequestSessionCookie
详细: Have request session cookie: domain=null, maxAge=-1, path=null, value=42D24D10BD954F66552649AE54FB86D2-n1, version=0, secure=false
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask doBackupSession
详细: Trying to store session in memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugResponseCookie
详细: Request finished, with Set-Cookie header: JSESSIONID=42D24D10BD954F66552649AE54FB86D2-n1; Path=/; HttpOnly
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Finished for session id 42D24D10BD954F66552649AE54FB86D2-n1, returning status SUCCESS
一月 23, 2016 10:58:05 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: <<<<<< Request finished: GET /testWeb/tss?state=postSigninForm ==================
一月 23, 2016 10:58:10 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: >>>>>> Request starting: GET /testWeb/tss?state=afterLogin (requestedSessionId 42D24D10BD954F66552649AE54FB86D2-n1) ==================
一月 23, 2016 10:58:10 下午 de.javakaffee.web.msm.SessionIdFormat createSessionId
详细: Creating new session id with orig id 'ping' and memcached id 'n1'.
一月 23, 2016 10:58:10 下午 de.javakaffee.web.msm.NodeAvailabilityCache updateIsNodeAvailable
详细: CacheLoader returned node availability 'true' for node 'n1'.
-----    afterLogin   -----
一月 23, 2016 10:58:10 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Loading session from memcached: 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.MemcachedSessionService loadFromMemcached
详细: Found session with id 42D24D10BD954F66552649AE54FB86D2-n1
you profile is: {name:alvis, balance:$10000 }
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.BackupSessionService backupSession
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Starting for session id 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.LockingStrategy onAfterBackupSession
详细: Stored session validity info for session 42D24D10BD954F66552649AE54FB86D2-n1
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.BackupSessionTask call
详细: Finished for session id 42D24D10BD954F66552649AE54FB86D2-n1, returning status SKIPPED
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.RequestTrackingHostValve logDebugRequestSessionCookie
详细: Have request session cookie: domain=null, maxAge=-1, path=null, value=42D24D10BD954F66552649AE54FB86D2-n1, version=0, secure=false
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.RequestTrackingHostValve invoke
详细: <<<<<< Request finished: GET /testWeb/tss?state=afterLogin ==================
一月 23, 2016 10:58:11 下午 de.javakaffee.web.msm.LockingStrategy pingSession
详细: The session was ping'ed successfully.
```
