### PR TITLE
Take into account multiple Set-Cookie headers in logDebugResponseCookie

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
+++ b/core/src/main/java/de/javakaffee/web/msm/RequestTrackingHostValve.java
@@ -17,6 +17,7 @@
 package de.javakaffee.web.msm;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -274,9 +275,13 @@ public abstract class RequestTrackingHostValve extends ValveBase {
     protected abstract String[] getSetCookieHeaders(final Response response);
 
     private void logDebugResponseCookie( final Response response ) {
-        final String header = response.getHeader("Set-Cookie");
-        if ( header != null && header.contains( _sessionCookieName ) ) {
-            _log.debug( "Request finished, with Set-Cookie header: " + header );
+        final Collection<String> headers = response.getHeaders("Set-Cookie");
+        if ( headers != null ) {
+            for (final String header : headers) {
+                if (header != null && header.contains(_sessionCookieName)) {
+                    _log.debug( "Request finished, with Set-Cookie header: " + header );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
While investigating a lost session on login issue, I came across this issue in trace level debugging.  Our app which uses Apache Shiro is currently sending out two Set-Cookie headers, one for deleting a remember me cookie and one for setting the JSESSIONID.  The current code doesn't always emit a log entry in logDebugResponseCookie presumably because which of these headers is actually processed is non-deterministic.  This small patch will go through all Set-Cookie headers and emit a log entry for each session cookie.