### PR TITLE
Kryo Builder Configuration - need separate builder for each new kryo

### DIFF
--- a/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoTranscoder.java
+++ b/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoTranscoder.java
@@ -90,25 +90,23 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
     private KryoFactory createKryoFactory(final ClassLoader classLoader,
                                           final String[] customConverterClassNames,
                                           final boolean copyCollectionsForSerialization) {
-
-        KryoBuilder kryoBuilder = new KryoBuilder() {
-            @Override
-            protected Kryo createKryo(ClassResolver classResolver, ReferenceResolver referenceResolver, StreamFactory streamFactory) {
-                return KryoTranscoder.this.createKryo(classResolver, referenceResolver, streamFactory,
-                        classLoader, customConverterClassNames, copyCollectionsForSerialization);
-            }
-        }.withInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
-
-        final List<KryoBuilderConfiguration> builderConfigs = load(KryoBuilderConfiguration.class, customConverterClassNames, classLoader);
-        for(KryoBuilderConfiguration config : builderConfigs) {
-            kryoBuilder = config.configure(kryoBuilder);
-        }
-
-        final KryoBuilder finalKryoBuilder = kryoBuilder;
         return new KryoFactory() {
             @Override
             public Kryo create() {
-                Kryo kryo = finalKryoBuilder.build();
+                KryoBuilder kryoBuilder = new KryoBuilder() {
+                    @Override
+                    protected Kryo createKryo(ClassResolver classResolver, ReferenceResolver referenceResolver, StreamFactory streamFactory) {
+                        return KryoTranscoder.this.createKryo(classResolver, referenceResolver, streamFactory,
+                                classLoader, customConverterClassNames, copyCollectionsForSerialization);
+                    }
+                }.withInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
+
+                final List<KryoBuilderConfiguration> builderConfigs = load(KryoBuilderConfiguration.class, customConverterClassNames, classLoader);
+                for(KryoBuilderConfiguration config : builderConfigs) {
+                    kryoBuilder = config.configure(kryoBuilder);
+                }
+
+                Kryo kryo = kryoBuilder.build();
 
                 kryo.setDefaultSerializer(new KryoDefaultSerializerFactory.SerializerFactoryAdapter(_defaultSerializerFactory));
 


### PR DESCRIPTION
The class resolver (inherits from com.esotericsoftware.kryo.util.DefaultClassResolver) needs to be unique for each kryo and cannot be shared among all new kryos created from the kryo factory.