### PR TITLE
Update kryo library from version 3.0.3 to 4.0.0 and kryo serializers …

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -1734,7 +1734,7 @@ public class MemcachedSessionService {
         _storage = storage;
     }
 
-    RequestTrackingHostValve getTrackingHostValve() {
+    public RequestTrackingHostValve getTrackingHostValve() {
         return _trackingHostValve;
     }
 

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -29,11 +29,6 @@
 			<version>4.0.0</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>juli</artifactId>
 			<version>${tomcat-version}</version>

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -21,12 +21,12 @@
 		<dependency>
 			<groupId>de.javakaffee</groupId>
 			<artifactId>kryo-serializers</artifactId>
-			<version>0.37</version>
+			<version>0.41</version>
 		</dependency>
 		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
-			<version>3.0.3</version>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -29,6 +29,11 @@
 			<version>4.0.0</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>juli</artifactId>
 			<version>${tomcat-version}</version>

--- a/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoBuilder.java
+++ b/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoBuilder.java
@@ -48,7 +48,10 @@ public class KryoBuilder {
     }
 
     protected Kryo createKryo(ClassResolver classResolver, ReferenceResolver referenceResolver, StreamFactory streamFactory) {
-        return new Kryo(classResolver, referenceResolver, streamFactory);
+        Kryo kryo = new Kryo(classResolver, referenceResolver, streamFactory);
+        // Maintain Kryo compatibility (pre version 4) - can turn this off by calling withOptimizedGenerics(false) 
+        kryo.getFieldSerializerConfig().setOptimizedGenerics(true);
+        return kryo;
     }
 
     public KryoBuilder withClassResolver(final ClassResolver classResolver) {
@@ -117,4 +120,14 @@ public class KryoBuilder {
         };
     }
     
+    public KryoBuilder withOptimizedGenerics(final boolean optimizedGenerics) {
+        return new KryoBuilder() {
+            @Override
+            public Kryo build() {
+                Kryo k = this.buildFrom(KryoBuilder.this);
+                k.getFieldSerializerConfig().setOptimizedGenerics(optimizedGenerics);
+                return k;
+            }
+        };
+    }
 }

--- a/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoTranscoder.java
+++ b/kryo-serializer/src/main/java/de/javakaffee/web/msm/serializer/kryo/KryoTranscoder.java
@@ -25,6 +25,8 @@ import de.javakaffee.kryoserializers.*;
 import de.javakaffee.web.msm.MemcachedBackupSession;
 import de.javakaffee.web.msm.SessionAttributesTranscoder;
 import de.javakaffee.web.msm.TranscoderDeserializationException;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.objenesis.strategy.StdInstantiatorStrategy;
@@ -149,15 +151,15 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
             private final List<SerializerFactory> serializerFactories = load(SerializerFactory.class, customConverterClassNames, classLoader, this);
 
             @Override
-            @SuppressWarnings( { "rawtypes", "unchecked" } )
-            public Serializer getDefaultSerializer(final Class clazz) {
-                final Serializer customSerializer = loadCustomSerializer( clazz, serializerFactories );
+            @SuppressWarnings( { "rawtypes" } )
+            public Serializer<?> getDefaultSerializer(final Class clazz) {
+                final Serializer<?> customSerializer = loadCustomSerializer( clazz, serializerFactories );
                 if ( customSerializer != null ) {
                     return customSerializer;
                 }
                 if ( copyCollectionsForSerialization ) {
                     // could also be installed via addDefaultSerializer
-                    final Serializer copyCollectionSerializer = loadCopyCollectionSerializer( clazz );
+                    final Serializer<?> copyCollectionSerializer = loadCopyCollectionSerializer( clazz );
                     if ( copyCollectionSerializer != null ) {
                         return copyCollectionSerializer;
                     }
@@ -165,10 +167,10 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
                 return super.getDefaultSerializer( clazz );
             }
 
-            private Serializer loadCustomSerializer(final Class<?> clazz, List<SerializerFactory> serializerFactories) {
+            private Serializer<?> loadCustomSerializer(final Class<?> clazz, List<SerializerFactory> serializerFactories) {
                 if ( serializerFactories != null ) {
                     for (SerializerFactory serializerFactory : serializerFactories) {
-                        final Serializer serializer = serializerFactory.newSerializer(clazz);
+                        final Serializer<?> serializer = serializerFactory.newSerializer(clazz);
                         if (serializer != null) {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("Loading custom serializer " + serializer.getClass().getName() + " for class " + clazz);
@@ -183,7 +185,7 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
         };
     }
     
-    private Serializer loadCopyCollectionSerializer( final Class<?> clazz ) {
+    private Serializer<?> loadCopyCollectionSerializer( final Class<?> clazz ) {
         if ( Collection.class.isAssignableFrom( clazz ) ) {
             if ( LOG.isDebugEnabled() ) {
                 LOG.debug( "Loading CopyForIterateCollectionSerializer for class " + clazz );
@@ -206,11 +208,15 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
     @Override
     public ConcurrentMap<String, Object> deserializeAttributes(final byte[] data ) {
         final Kryo kryo = _kryoPool.borrow();
+        Input in = null;
         try {
-            return kryo.readObject(new Input(data), ConcurrentHashMap.class);
+            in = kryo.getStreamFactory().getInput(data);
+            return kryo.readObject(in, ConcurrentHashMap.class);
         } catch ( final RuntimeException e ) {
             throw new TranscoderDeserializationException( e );
         } finally {
+            IOUtils.closeQuietly(in);
+            kryo.reset();   // to be safe
             _kryoPool.release(kryo);
         }
     }
@@ -221,18 +227,25 @@ public class KryoTranscoder implements SessionAttributesTranscoder {
     @Override
     public byte[] serializeAttributes( final MemcachedBackupSession session, final ConcurrentMap<String, Object> attributes ) {
         final Kryo kryo = _kryoPool.borrow();
+        Output out = null;
         try {
             /**
              * Creates an ObjectStream with an initial buffer size of 50KB and a maximum size of 1000KB.
              */
-            Output out = new Output(_initialBufferSize, _maxBufferSize);
+            out = kryo.getStreamFactory().getOutput(_initialBufferSize, _maxBufferSize);
             kryo.writeObject(out, attributes);
             return out.toBytes();
         } catch ( final RuntimeException e ) {
             throw new TranscoderDeserializationException( e );
         } finally {
+            IOUtils.closeQuietly(out);
+            kryo.reset();   // to be safe
             _kryoPool.release(kryo);
         }
+    }
+
+    public KryoPool getKryoPool() {
+        return _kryoPool;
     }
 
     private <T> List<T> load( Class<T> type, final String[] customConverterClassNames, final ClassLoader classLoader) {

--- a/kryo-serializer/src/test/java/de/javakaffee/web/msm/serializer/kryo/KryoBuilderTest.java
+++ b/kryo-serializer/src/test/java/de/javakaffee/web/msm/serializer/kryo/KryoBuilderTest.java
@@ -53,6 +53,7 @@ public class KryoBuilderTest {
 								.withInstantiatorStrategy(instantiatorStrategy)
 								.withRegistrationRequired(true) // Kryo default is false
 								.withReferences(false) // Kryo default is true
+								.withOptimizedGenerics(false)
 								.build();
 					}
 				} },
@@ -71,6 +72,7 @@ public class KryoBuilderTest {
 								.withInstantiatorStrategy(instantiatorStrategy)
 								.withRegistrationRequired(true) // Kryo default is false
 								.withReferences(false) // Kryo default is true
+								.withOptimizedGenerics(false)
 								.withKryoCustomization(enableAsm)
 								.withKryoCustomization(registerMyCollectionSerializer)
 								.build();
@@ -89,7 +91,7 @@ public class KryoBuilderTest {
 
 		KryoCustomization enableAsm = new KryoCustomization() {
 			@Override public void customize(Kryo kryo) {
-				kryo.setAsmEnabled(true); // Kryo default false
+				kryo.getFieldSerializerConfig().setUseAsm(true); // Kryo default false
 			}
 		};
 
@@ -108,8 +110,9 @@ public class KryoBuilderTest {
 		assertSame(kryo.getInstantiatorStrategy(), instantiatorStrategy);
 		assertTrue(kryo.isRegistrationRequired());
 		assertFalse(kryo.getReferences());
-		assertTrue(kryo.getAsmEnabled());
+		assertTrue(kryo.getFieldSerializerConfig().isUseAsm());
 		assertSame(kryo.getDefaultSerializer(Collection.class), collectionSerializer);
+		assertFalse(kryo.getFieldSerializerConfig().isOptimizedGenerics());
 	}
 
 	static abstract class BuildKryo {


### PR DESCRIPTION
…library from version 0.37 to 0.41.

Modified the builder to support turning field generics off/on and exposed the Kryo Pool from the transcoder if you it for something other than session map serialization.  Use StreamFactory to create Input/output objects.