### PR TITLE
Support for Redis Cluster

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedNodesManager.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedNodesManager.java
@@ -81,6 +81,7 @@ public class MemcachedNodesManager {
     private final LinkedHashMap<InetSocketAddress, String> _address2Ids;
     private final boolean _encodeNodeIdInSessionId;
     private final StorageKeyFormat _storageKeyFormat;
+	private final String _redisMode;
     @Nullable
 	private NodeIdService _nodeIdService;
 	private SessionIdFormat _sessionIdFormat;
@@ -97,12 +98,13 @@ public class MemcachedNodesManager {
      */
 	public MemcachedNodesManager(final String memcachedNodes, @Nonnull final NodeIdList primaryNodeIds, @Nonnull final List<String> failoverNodeIds,
 			@Nonnull final LinkedHashMap<InetSocketAddress, String> address2Ids,
-			@Nullable final StorageKeyFormat storageKeyFormat, @Nullable final StorageClientCallback storageClientCallback) {
+			@Nullable final StorageKeyFormat storageKeyFormat, @Nullable final StorageClientCallback storageClientCallback, @Nonnull String redisMode) {
 		_memcachedNodes = memcachedNodes;
 		_primaryNodeIds = primaryNodeIds;
 		_failoverNodeIds = failoverNodeIds;
 		_address2Ids = address2Ids;
 		_storageKeyFormat = storageKeyFormat;
+		_redisMode = redisMode;
 
         _encodeNodeIdInSessionId = !((getCountNodes() <= 1 || isCouchbaseConfig(memcachedNodes)) && _primaryNodeIds.isEmpty());
 
@@ -180,7 +182,7 @@ public class MemcachedNodesManager {
 	 */
 	@Nonnull
     public static MemcachedNodesManager createFor(final String memcachedNodes, final String failoverNodes, final StorageKeyFormat storageKeyFormat,
-            final StorageClientCallback storageClientCallback) {
+            final StorageClientCallback storageClientCallback, final String redisMode) {
 		if ( memcachedNodes == null || memcachedNodes.trim().isEmpty() ) {
 			throw new IllegalArgumentException("null or empty memcachedNodes not allowed.");
 		}
@@ -189,7 +191,7 @@ public class MemcachedNodesManager {
 		if (memcachedNodes.startsWith("redis://") || memcachedNodes.startsWith("rediss://")) {
 		    // Redis configuration
 		    return new MemcachedNodesManager(memcachedNodes, new NodeIdList(), new ArrayList<String>(),
-		            new LinkedHashMap<InetSocketAddress, String>(), storageKeyFormat, storageClientCallback);
+		            new LinkedHashMap<InetSocketAddress, String>(), storageKeyFormat, storageClientCallback, redisMode);
 		}
 
         if ( !NODES_PATTERN.matcher( memcachedNodes ).matches() && !SINGLE_NODE_PATTERN.matcher(memcachedNodes).matches()
@@ -247,7 +249,7 @@ public class MemcachedNodesManager {
 	        }
         }
 
-        return new MemcachedNodesManager(memcachedNodes, primaryNodeIds, failoverNodeIds, address2Ids, storageKeyFormat, storageClientCallback);
+        return new MemcachedNodesManager(memcachedNodes, primaryNodeIds, failoverNodeIds, address2Ids, storageKeyFormat, storageClientCallback, redisMode);
 	}
 
     private static InetSocketAddress getSingleShortNodeDefinition(final Matcher singleNodeMatcher) {
@@ -569,4 +571,7 @@ public class MemcachedNodesManager {
         return result;
     }
 
+	public String getRedisMode() {
+		return _redisMode;
+	}
 }

--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -434,7 +434,7 @@ public class MemcachedSessionService {
      * Initialize this manager.
      */
     void startInternal() throws LifecycleException {
-        _log.info( getClass().getSimpleName() + " starts initialization... (configured" +
+        _log.info( MemcachedSessionService.class.getSimpleName() + " starts initialization... (configured" +
                 " nodes definition " + _memcachedNodes + ", failover nodes " + _failoverNodes + ")" );
 
         _statistics = Statistics.create( _enableStatistics );
@@ -460,13 +460,14 @@ public class MemcachedSessionService {
         _backupSessionService = new BackupSessionService( _transcoderService, _sessionBackupAsync, _sessionBackupTimeout,
                 _backupThreadCount, _storage, _memcachedNodesManager, _statistics );
 
-        _log.info( "--------\n- " + getClass().getSimpleName() + " finished initialization:" +
+        _log.info( "--------\n- " + MemcachedSessionService.class.getSimpleName() + " finished initialization:" +
                 "\n- sticky: "+ _sticky +
                 "\n- operation timeout: " + _operationTimeout +
                 "\n- node ids: " + _memcachedNodesManager.getPrimaryNodeIds() +
                 "\n- failover node ids: " + _memcachedNodesManager.getFailoverNodeIds() +
                 "\n- storage key prefix: " + _memcachedNodesManager.getStorageKeyFormat().prefix +
                 "\n- locking mode: " + _lockingMode + " (expiration: " + _lockExpiration + "s)" +
+                "\n- redis mode: " + _redisMode +
                 "\n--------");
 
     }

--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedSessionService.java
@@ -89,6 +89,9 @@ public class MemcachedSessionService {
      */
     protected static final String NEW_SESSION_ID = "msm.session.id";
 
+    public static final String REDIS_MODE_NORMAL = "normal";
+    public static final String REDIS_MODE_CLUSTER = "cluster";
+
     protected final Log _log = LogFactory.getLog( getClass() );
 
     // -------------------- configuration properties --------------------
@@ -193,6 +196,8 @@ public class MemcachedSessionService {
 
     private String _storageKeyPrefix = StorageKeyFormat.WEBAPP_VERSION;
 
+    private String _redisMode = REDIS_MODE_NORMAL;
+    
     // -------------------- END configuration properties --------------------
 
     protected Statistics _statistics;
@@ -492,7 +497,7 @@ public class MemcachedSessionService {
         final Context context = _manager.getContext();
         final String webappVersion = Reflections.invoke(context, "getWebappVersion", null);
         final StorageKeyFormat storageKeyFormat = StorageKeyFormat.of(_storageKeyPrefix, context.getParent().getName(), context.getName(), webappVersion);
-		return MemcachedNodesManager.createFor( memcachedNodes, failoverNodes, storageKeyFormat, _storageClientCallback);
+		return MemcachedNodesManager.createFor( memcachedNodes, failoverNodes, storageKeyFormat, _storageClientCallback, _redisMode);
 	}
 
     private TranscoderService createTranscoderService( final Statistics statistics ) {
@@ -1827,4 +1832,16 @@ public class MemcachedSessionService {
         _storageKeyPrefix = storageKeyPrefix;
     }
 
+	public String getRedisMode() {
+		return _redisMode;
+	}
+
+	public void setRedisMode(String redisMode) {
+        if ( !REDIS_MODE_NORMAL.equals( redisMode )
+                && !REDIS_MODE_CLUSTER.equals( redisMode ) ) {
+            _log.warn( "Illegal redisMode " + redisMode + ", using default (" + _redisMode + ")." );
+            return;
+        }
+		this._redisMode = redisMode;
+	}
 }

--- a/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
@@ -15,6 +15,9 @@
  */
 package de.javakaffee.web.msm;
 
+import de.javakaffee.web.msm.storage.MemcachedStorageClient;
+import de.javakaffee.web.msm.storage.RedisClusterStorageClient;
+import de.javakaffee.web.msm.storage.StorageClient;
 import net.spy.memcached.BinaryConnectionFactory;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -22,10 +25,6 @@ import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
-
-import de.javakaffee.web.msm.storage.MemcachedStorageClient;
-import de.javakaffee.web.msm.storage.RedisStorageClient;
-import de.javakaffee.web.msm.storage.StorageClient;
 
 /**
  * Factory to create the {@link MemcachedClient}, either directly the spymemcached {@link MemcachedClient}
@@ -48,7 +47,7 @@ public class StorageClientFactory {
                                                 final long maxReconnectDelay, final Statistics statistics ) {
         try {
             if (memcachedNodesManager.isRedisConfig()) {
-                return new RedisStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
+                return new RedisClusterStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
             }
             final ConnectionType connectionType = ConnectionType.valueOf(memcachedNodesManager.isCouchbaseBucketConfig(), username, password);
             if (connectionType.isCouchbaseBucketConfig()) {

--- a/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
@@ -17,6 +17,7 @@ package de.javakaffee.web.msm;
 
 import de.javakaffee.web.msm.storage.MemcachedStorageClient;
 import de.javakaffee.web.msm.storage.RedisClusterStorageClient;
+import de.javakaffee.web.msm.storage.RedisStorageClient;
 import de.javakaffee.web.msm.storage.StorageClient;
 import net.spy.memcached.BinaryConnectionFactory;
 import net.spy.memcached.ConnectionFactory;
@@ -35,6 +36,7 @@ import net.spy.memcached.auth.PlainCallbackHandler;
 public class StorageClientFactory {
 
     public static final String PROTOCOL_BINARY = "binary";
+    public static final String REDIS_MODE_CLUSTER = "cluster";
 
     static interface CouchbaseClientFactory {
         MemcachedClient createCouchbaseClient(MemcachedNodesManager memcachedNodesManager,
@@ -47,7 +49,11 @@ public class StorageClientFactory {
                                                 final long maxReconnectDelay, final Statistics statistics ) {
         try {
             if (memcachedNodesManager.isRedisConfig()) {
-                return new RedisClusterStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
+            	if(REDIS_MODE_CLUSTER.equals(memcachedNodesManager.getRedisMode())) {
+            		return new RedisClusterStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
+            	} else {
+            		return new RedisStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
+            	}
             }
             final ConnectionType connectionType = ConnectionType.valueOf(memcachedNodesManager.isCouchbaseBucketConfig(), username, password);
             if (connectionType.isCouchbaseBucketConfig()) {

--- a/core/src/main/java/de/javakaffee/web/msm/storage/RedisClusterStorageClient.java
+++ b/core/src/main/java/de/javakaffee/web/msm/storage/RedisClusterStorageClient.java
@@ -1,0 +1,176 @@
+package de.javakaffee.web.msm.storage;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
+import de.javakaffee.web.msm.NamedThreadFactory;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class RedisClusterStorageClient implements StorageClient {
+    protected static final Log _log = LogFactory.getLog(RedisClusterStorageClient.class);
+
+	private JedisCluster jedisCluster;
+    private final ExecutorService _executor = Executors.newCachedThreadPool(new NamedThreadFactory("msm-redis-client"));
+
+    /**
+     * Creates a <code>MemcachedStorageClient</code> instance which connects to the given Redis URL.
+     *
+     * @param redisUrl redis URL
+     * @param operationTimeout the timeout to set for connection and socket timeout on the underlying jedis client.
+     */
+    public RedisClusterStorageClient(String nodes, long operationTimeout) {
+        if (nodes == null)
+            throw new NullPointerException("Param \"nodes\" may not be null");
+        
+        if (_log.isDebugEnabled())
+            _log.debug(format("Creating RedisClusterStorageClient with nodes \"%s\"", nodes));
+
+        try {
+			Set<HostAndPort> jedisClusterNodes = new HashSet<HostAndPort>();
+			for (String server : nodes.split(",")) {
+				URI uri = URI.create(server);
+				jedisClusterNodes.add(new HostAndPort(uri.getHost(), uri.getPort()));
+			}
+
+			GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
+			poolConfig.setMaxTotal(200);
+			poolConfig.setMaxIdle(20);
+			poolConfig.setMinIdle(5);
+			poolConfig.setMaxWaitMillis(operationTimeout);
+
+			jedisCluster = new JedisCluster(jedisClusterNodes, poolConfig);
+        } catch (Exception e) {
+            throw new RuntimeException("Error parsing nodes", e);
+        }
+    }
+
+    @Override
+    public Future<Boolean> add(final String key, final int exp, final byte[] o) {
+        
+        if (_log.isDebugEnabled())
+            _log.debug(format("Adding key to Redis (key=%s, exp=%s, o=%s)", key, exp, o.getClass().getName()));
+        
+        return _executor.submit(new RedisCommandCallable<Boolean>() {
+            private volatile boolean _setCompleted;
+            
+            @Override protected Boolean execute() throws Exception {
+                byte[] kb = keyBytes(key);
+                if (_setCompleted || jedisCluster.setnx(kb, o) == 1) {
+                    _setCompleted = true; // make sure to not call setnx() a second time if connection fails
+                    if (exp == 0)
+                        return true;
+                    else
+                        return jedisCluster.expire(kb, convertExp(exp)) == 1;
+                } else {
+                    return false;
+                }
+            }
+        });
+    }
+
+    @Override
+    public Future<Boolean> set(final String key, final int exp, final byte[] o) {
+        if (_log.isDebugEnabled())
+            _log.debug(format("Setting key in Redis (key=%s, exp=%s, o=%s)", key, exp, o.getClass().getName()));
+        
+        return _executor.submit(new RedisCommandCallable<Boolean>() {
+            @Override protected Boolean execute() throws Exception {
+                if (exp == 0)
+                    return jedisCluster.set(keyBytes(key), o).equals("OK");
+                else
+                    return jedisCluster.setex(keyBytes(key), convertExp(exp), o).equals("OK");
+            }
+        });
+    }
+    
+    @Override
+    public byte[] get(final String key) {
+        if (_log.isDebugEnabled())
+            _log.debug(format("Getting key from Redis (key=%s)", key));
+        
+        Callable<byte[]> callable = new RedisCommandCallable<byte[]>() {
+            @Override protected byte[] execute() throws Exception {
+                return jedisCluster.get(keyBytes(key));
+            }
+        };
+        
+        // Execute callable synchronously since we need to wait for the result anyway
+        try {
+            return callable.call();
+        }
+        catch (Exception e) {
+            if (e instanceof RuntimeException)
+                throw (RuntimeException)e;
+            else
+                throw new RuntimeException("Error getting key from Redis", e);
+        }
+    }
+    
+    @Override
+    public Future<Boolean> delete(final String key) {
+        if (_log.isDebugEnabled())
+            _log.debug(format("Deleting key in Redis (key=%s)", key));
+
+        return _executor.submit(new RedisCommandCallable<Boolean>() {
+            @Override protected Boolean execute() throws Exception {
+                return jedisCluster.del(keyBytes(key)) == 1;
+            }
+        });
+    }
+
+    @Override
+    public void shutdown() {
+    	try {
+			jedisCluster.close();
+		} catch (IOException exception) {
+			// TODO Auto-generated catch block
+			exception.printStackTrace();
+		}
+    }
+    
+    private static int convertExp(int exp) {
+        if (exp <= 60*60*24*30) // thirty days
+            return exp;
+        else
+            return Math.max(exp - (int)(System.currentTimeMillis() / 1000), 1);
+    }
+    
+    private static byte[] keyBytes(String key) {
+        try {
+            return key.getBytes("UTF-8");
+        } catch (java.io.UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+    
+    private abstract class RedisCommandCallable<T> implements Callable<T> {
+        @Override
+        public T call() throws Exception {
+            try {
+                return execute();
+            } catch (JedisConnectionException e) {
+            	e.printStackTrace();
+                if (_log.isDebugEnabled())
+                    _log.debug("Error occurred: " + e.getMessage());
+            }
+            return null;
+        }
+        
+        protected abstract T execute() throws Exception;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,14 @@
 
 	<modules>
 		<module>core</module>
-		<module>tomcat6</module>
+<!-- 		<module>tomcat6</module> -->
 		<module>tomcat7</module>
 		<module>tomcat8</module>
-		<module>kryo-serializer</module>
+<!--		<module>kryo-serializer</module>
 		<module>javolution-serializer</module>
 		<module>xstream-serializer</module>
 		<module>flexjson-serializer</module>
-		<module>serializer-benchmark</module>
+		<module>serializer-benchmark</module>-->
 	</modules>
 
 	<build>
@@ -220,7 +220,7 @@
 		<tomcat-version>${tomcat6-version}</tomcat-version>
 		<slf4j-version>1.7.15</slf4j-version>
 		<hibernate-core-version>5.0.7.Final</hibernate-core-version>
-		<couchbasemock-version>0.5-69e953bd</couchbasemock-version>
+		<couchbasemock-version>0.5-SNAPSHOT</couchbasemock-version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,11 @@
 		<module>tomcat6</module>
 		<module>tomcat7</module>
 		<module>tomcat8</module>
-<!--		<module>kryo-serializer</module>
+		<module>kryo-serializer</module>
 		<module>javolution-serializer</module>
 		<module>xstream-serializer</module>
 		<module>flexjson-serializer</module>
-		<module>serializer-benchmark</module>-->
+		<module>serializer-benchmark</module>
 	</modules>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 	<modules>
 		<module>core</module>
-<!-- 		<module>tomcat6</module> -->
+		<module>tomcat6</module>
 		<module>tomcat7</module>
 		<module>tomcat8</module>
 <!--		<module>kryo-serializer</module>

--- a/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -627,6 +627,10 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         _msm.setStorageKeyPrefix(storageKeyPrefix);
     }
 
+    public void setRedisMode(final String redisMode) {
+        _msm.setRedisMode(redisMode);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -548,6 +548,10 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         _msm.setStorageKeyPrefix(storageKeyPrefix);
     }
 
+    public void setRedisMode(final String redisMode) {
+        _msm.setRedisMode(redisMode);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -531,6 +531,10 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         _msm.setStorageKeyPrefix(storageKeyPrefix);
     }
 
+    public void setRedisMode(final String redisMode) {
+        _msm.setRedisMode(redisMode);
+    }
+    
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Hi, 

This is a new pull request to add support for **Redis Cluster**.

A new storage client have been added : **RedisClusterStorageClient.java**
A new optional parameter is available: **redisMode** (normal or cluster)

If the redisMode is setted to "cluster", the RedisClusterStorageClient will be used instead of RedisStorageClient.

```
    <Manager className="de.javakaffee.web.msm.MemcachedBackupSessionManager"
        memcachedNodes="redis://172.16.50.12:7000,redis://172.16.50.12:7001,redis://172.16.50.12:7002"
        sticky="false"
        requestUriIgnorePattern=".*\.(ico|png|gif|jpg|css|js)$"
        redisMode="cluster"
     />

```