### PR TITLE
Add support for Redis Auth.

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/StorageClientFactory.java
@@ -48,7 +48,7 @@ public class StorageClientFactory {
                                                 final long maxReconnectDelay, final Statistics statistics ) {
         try {
             if (memcachedNodesManager.isRedisConfig()) {
-                return new RedisStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout);
+                return new RedisStorageClient(memcachedNodesManager.getMemcachedNodes(), operationTimeout, password);
             }
             final ConnectionType connectionType = ConnectionType.valueOf(memcachedNodesManager.isCouchbaseBucketConfig(), username, password);
             if (connectionType.isCouchbaseBucketConfig()) {


### PR DESCRIPTION
Add support for Redis Auth.
To configure, provide password attribute in context.xml. For eg:-
<Context>
  ...
  <Manager className="de.javakaffee.web.msm.MemcachedBackupSessionManager"
    memcachedNodes="n1:host1.yourdomain.com:11211,n2:host2.yourdomain.com:11211"
    failoverNodes="n1"
    requestUriIgnorePattern=".*\.(ico|png|gif|jpg|css|js)$"
    transcoderFactoryClass="de.javakaffee.web.msm.serializer.kryo.KryoTranscoderFactory"
    password="YourPassword"
    />
</Context>