### PR TITLE
Added timeout for blocking calls in RequestTrackingContextValve

### DIFF
--- a/core/src/main/java/de/javakaffee/web/msm/MemcachedNodesManager.java
+++ b/core/src/main/java/de/javakaffee/web/msm/MemcachedNodesManager.java
@@ -151,6 +151,9 @@ public class MemcachedNodesManager {
                 	storageClientCallback.get(_sessionIdFormat.createSessionId( "ping", key ) );
                     return true;
                 } catch ( final Exception e ) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("removing node due to exception.", e);
+                    }
                     return false;
                 }
             }
@@ -184,7 +187,7 @@ public class MemcachedNodesManager {
 		if ( memcachedNodes == null || memcachedNodes.trim().isEmpty() ) {
 			throw new IllegalArgumentException("null or empty memcachedNodes not allowed.");
 		}
-		
+
         // Support a Redis URL in the form "redis://hostname:port" or "rediss://" (for SSL connections) like the client "Lettuce" does
 		if (memcachedNodes.startsWith("redis://") || memcachedNodes.startsWith("rediss://")) {
 		    // Redis configuration
@@ -415,11 +418,11 @@ public class MemcachedNodesManager {
 		}
 	}
 
-    /**
-     * Determines, if the given nodeId is available.
-     * @param nodeId the node to check, not <code>null</code>.
-     * @return <code>true</code>, if the node is marked as available
-     */
+	/**
+	 * Determines, if the given nodeId is available.
+	 * @param nodeId the node to check, not <code>null</code>.
+	 * @return <code>true</code>, if the node is marked as available
+	 */
 	public boolean isNodeAvailable(final String nodeId) {
 		return _nodeIdService.isNodeAvailable(nodeId);
 	}

--- a/core/src/main/java/de/javakaffee/web/msm/TimeoutExecutor.java
+++ b/core/src/main/java/de/javakaffee/web/msm/TimeoutExecutor.java
@@ -1,0 +1,48 @@
+package de.javakaffee.web.msm;
+
+import org.apache.juli.logging.Log;
+
+import java.util.concurrent.*;
+
+import static de.javakaffee.web.msm.Configurations.getSystemProperty;
+
+/**
+ * The spymemcached library can block for a quite long time (currently 10 seconds),
+ * if its operations queue is full. Since a call to an external system should not
+ * block the page delivery for that long, calls can now be timeout with this class.
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+final class TimeoutExecutor {
+
+    private TimeoutExecutor() {
+    }
+
+    static final String CALLABLE_TIMEOUT_MS_KEY = "msm.timeoutExecutor.timeoutMs";
+    static final String POOL_SIZE_KEY = "msm.timeoutExecutor.poolSize";
+
+    static final int DEFAULT_CALLABLE_TIMEOUT_MS = getSystemProperty(CALLABLE_TIMEOUT_MS_KEY, 1500);
+    static final int DEFAULT_TIMEOUT_EXECUTOR_POOL_SIZE = getSystemProperty(POOL_SIZE_KEY, 10);
+
+    private static ExecutorService TIMEOUT_EXECUTOR = Executors.newFixedThreadPool(DEFAULT_TIMEOUT_EXECUTOR_POOL_SIZE,
+            new NamedThreadFactory("TimeoutExecutor"));
+
+    static String callWithTimeout(final Callable<String> callable, final int timeoutMs, final Log log) {
+        try {
+            return TIMEOUT_EXECUTOR.submit(callable).get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+            logException(log, e, timeoutMs);
+        } catch (final ExecutionException e) {
+            logException(log, e, timeoutMs);
+        } catch (final TimeoutException e) {
+            logException(log, e, timeoutMs);
+        }
+        return null;
+    }
+
+    private static void logException(final Log log, final Exception e, final int timeoutMs) {
+        if (log.isDebugEnabled()) {
+            log.debug("Exception on callable with timeoue (timeoutMs: " + timeoutMs + ").", e);
+        }
+    }
+}

--- a/core/src/test/java/de/javakaffee/web/msm/TimeoutExecutorTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/TimeoutExecutorTest.java
@@ -1,0 +1,54 @@
+package de.javakaffee.web.msm;
+
+import org.apache.juli.logging.Log;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit Tests for the TimeoutExecutor.
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+public class TimeoutExecutorTest {
+    @Test
+    public final void shouldNotBeTimedOut() {
+        // given
+        final Log log = mock(Log.class);
+        final String expectedResult = "foo";
+        final Callable<String> callable = new Callable<String>() {
+            @Override
+            public String call() {
+                return expectedResult;
+            }
+        };
+        final int timeoutMs = 200;
+        // when
+        final String actualResult = TimeoutExecutor.callWithTimeout(callable, timeoutMs, log);
+        // then
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public final void shouldBeTimedOut() {
+        // given
+        final Log log = mock(Log.class);
+        final String expectedResult = null;
+        final Callable<String> callable = new Callable<String>() {
+            @Override
+            public String call() throws InterruptedException {
+                Thread.sleep(400);
+                return "";
+            }
+        };
+        final int timeoutMs = 200;
+        // when
+        final String actualResult = TimeoutExecutor.callWithTimeout(callable, timeoutMs, log);
+        // then
+        assertEquals(actualResult, expectedResult);
+    }
+}


### PR DESCRIPTION
- The `spymemcached` library internally uses a `LinkedBlockingQueue` with a maximum capacity to store operations.
- If this queue is filled up, e.g. due to memcached problems, new adds timeout after a longer time period (currently 10s).
- This internal queue should not be able block the page delivery of the tomcat thread for that long.
Therefore, this commit proposes a timeout on the MSM side to handle this situation.

Here is a corresponding ThreadDump:

```
"http-nio-8443-exec-9" #289 daemon prio=5 os_prio=0 tid=0x00007fb5c02c0800 nid=0xc53 waiting on condition [0x00007fb445336000]
   java.lang.Thread.State: TIMED_WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000006dfe00150> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)
        at java.util.concurrent.LinkedBlockingQueue.offer(LinkedBlockingQueue.java:385)
        at net.spy.memcached.protocol.TCPMemcachedNodeImpl.addOp(TCPMemcachedNodeImpl.java:387)
        at net.spy.memcached.MemcachedConnection.addOperation(MemcachedConnection.java:1285)
        at net.spy.memcached.MemcachedConnection.addOperation(MemcachedConnection.java:1247)
        at net.spy.memcached.MemcachedConnection.enqueueOperation(MemcachedConnection.java:1203)
        at net.spy.memcached.MemcachedClient.asyncGet(MemcachedClient.java:1044)
        at net.spy.memcached.MemcachedClient.get(MemcachedClient.java:1229)
        at de.javakaffee.web.msm.storage.MemcachedStorageClient.get(MemcachedStorageClient.java:62)
        at de.javakaffee.web.msm.MemcachedSessionService$2.get(MemcachedSessionService.java:486)
        at de.javakaffee.web.msm.MemcachedNodesManager$2.isNodeAvailable(MemcachedNodesManager.java:151)
        at de.javakaffee.web.msm.MemcachedNodesManager$2.isNodeAvailable(MemcachedNodesManager.java:146)
        at de.javakaffee.web.msm.NodeAvailabilityCache.updateIsNodeAvailable(NodeAvailabilityCache.java:132)
        at de.javakaffee.web.msm.NodeAvailabilityCache.isNodeAvailable(NodeAvailabilityCache.java:121)
        at de.javakaffee.web.msm.NodeIdService.isNodeAvailable(NodeIdService.java:91)
        at de.javakaffee.web.msm.NodeIdService.getMemcachedNodeId(NodeIdService.java:184)
        at de.javakaffee.web.msm.NodeIdService.getNewNodeIdIfUnavailable(NodeIdService.java:206)
        at de.javakaffee.web.msm.MemcachedNodesManager.getNewSessionIdIfNodeFromSessionIdUnavailable(MemcachedNodesManager.java:505)
        at de.javakaffee.web.msm.MemcachedSessionService.changeSessionIdOnMemcachedFailover(MemcachedSessionService.java:901)
        at de.javakaffee.web.msm.RequestTrackingContextValve.changeRequestedSessionId(RequestTrackingContextValve.java:128)
        at de.javakaffee.web.msm.RequestTrackingContextValve.invoke(RequestTrackingContextValve.java:98)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
        at de.javakaffee.web.msm.RequestTrackingHostValve.invoke(RequestTrackingHostValve.java:158)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:617)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:518)
        at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1091)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:668)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1527)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1484)
        - locked <0x00000006dfddc458> (a org.apache.tomcat.util.net.SecureNioChannel)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:748)
```
I'm happy about feedback and an assessment, whether other calls should to `spymemcached` should be wrapped.