### PR TITLE
Issues/430 custom serializers: Allow for custom serialization on all things stored in cache backend to mitigate security and performance problems

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>memcached-session-manager</artifactId>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>memcached-session-manager core</name>
 	<description>The msm core, provides java serialization strategy.</description>

--- a/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOFactory.java
@@ -1,0 +1,8 @@
+package de.javakaffee.web.msm;
+
+public class DefaultObjectIOFactory implements ObjectIOFactory {
+	@Override
+	public ObjectIOStrategy createObjectIOStrategy() {
+		return new DefaultObjectIOStrategy();
+	}
+}

--- a/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOFactory.java
@@ -1,8 +1,10 @@
 package de.javakaffee.web.msm;
 
+import de.javakaffee.web.msm.MemcachedSessionService.SessionManager;
+
 public class DefaultObjectIOFactory implements ObjectIOFactory {
 	@Override
-	public ObjectIOStrategy createObjectIOStrategy() {
+	public ObjectIOStrategy createObjectIOStrategy(final SessionManager _manager) {
 		return new DefaultObjectIOStrategy();
 	}
 }

--- a/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOStrategy.java
+++ b/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOStrategy.java
@@ -1,0 +1,22 @@
+package de.javakaffee.web.msm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+
+public class DefaultObjectIOStrategy implements ObjectIOStrategy {
+
+	@Override
+	public ObjectInput createObjectInput(InputStream is) throws IOException {
+		return new ObjectInputStream(is);
+	}
+
+	@Override
+	public ObjectOutput createObjectOutput(OutputStream os) throws IOException {
+		return new ObjectOutputStream(os);
+	}
+}

--- a/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOStrategy.java
+++ b/core/src/main/java/de/javakaffee/web/msm/DefaultObjectIOStrategy.java
@@ -9,14 +9,13 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
 public class DefaultObjectIOStrategy implements ObjectIOStrategy {
-
 	@Override
-	public ObjectInput createObjectInput(InputStream is) throws IOException {
+	public ObjectInput createObjectInput(final InputStream is) throws IOException {
 		return new ObjectInputStream(is);
 	}
 
 	@Override
-	public ObjectOutput createObjectOutput(OutputStream os) throws IOException {
+	public ObjectOutput createObjectOutput(final OutputStream os) throws IOException {
 		return new ObjectOutputStream(os);
 	}
 }

--- a/core/src/main/java/de/javakaffee/web/msm/ObjectIOFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/ObjectIOFactory.java
@@ -1,5 +1,7 @@
 package de.javakaffee.web.msm;
 
+import de.javakaffee.web.msm.MemcachedSessionService.SessionManager;
+
 public interface ObjectIOFactory {
-	ObjectIOStrategy createObjectIOStrategy();
+	ObjectIOStrategy createObjectIOStrategy(SessionManager sessionManager);
 }

--- a/core/src/main/java/de/javakaffee/web/msm/ObjectIOFactory.java
+++ b/core/src/main/java/de/javakaffee/web/msm/ObjectIOFactory.java
@@ -1,0 +1,5 @@
+package de.javakaffee.web.msm;
+
+public interface ObjectIOFactory {
+	ObjectIOStrategy createObjectIOStrategy();
+}

--- a/core/src/main/java/de/javakaffee/web/msm/ObjectIOStrategy.java
+++ b/core/src/main/java/de/javakaffee/web/msm/ObjectIOStrategy.java
@@ -1,0 +1,13 @@
+package de.javakaffee.web.msm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+
+public interface ObjectIOStrategy {
+    ObjectInput createObjectInput( InputStream is ) throws IOException;
+
+    ObjectOutput createObjectOutput( OutputStream os ) throws IOException;
+}

--- a/core/src/main/java/de/javakaffee/web/msm/TranscoderService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/TranscoderService.java
@@ -79,13 +79,13 @@ public class TranscoderService {
         _attributesTranscoder = attributesTranscoder;
         _objectIOStrategy = new DefaultObjectIOStrategy();
     }
-    
+
     /**
      * Creates a new {@link TranscoderService}.
      *
      * @param attributesTranscoder the {@link SessionAttributesTranscoder} strategy to use.
      */
-    public TranscoderService( final SessionAttributesTranscoder attributesTranscoder, ObjectIOStrategy objectIOStrategy) {
+    public TranscoderService( final SessionAttributesTranscoder attributesTranscoder, final ObjectIOStrategy objectIOStrategy) {
         _attributesTranscoder = attributesTranscoder;
         _objectIOStrategy = objectIOStrategy;
     }
@@ -512,7 +512,7 @@ public class TranscoderService {
         for ( int i = 0; i < maxBytes; i++ ) {
             final int pos = maxBytes - i - 1; // the position of the byte in the number
             final int idx = beginIndex + pos; // the index in the data array
-            data[idx] = (byte) ( ( num >> ( 8 * i ) ) & 0xff );
+            data[idx] = (byte) ( num >> 8 * i & 0xff );
         }
         return beginIndex + maxBytes;
     }
@@ -521,7 +521,7 @@ public class TranscoderService {
         long result = 0;
         for ( int i = 0; i < numBytes; i++ ) {
             final byte b = data[beginIndex + i];
-            result = ( result << 8 ) | ( b < 0
+            result = result << 8 | ( b < 0
                 ? 256 + b
                 : b );
         }

--- a/core/src/main/java/de/javakaffee/web/msm/TranscoderService.java
+++ b/core/src/main/java/de/javakaffee/web/msm/TranscoderService.java
@@ -18,11 +18,10 @@ package de.javakaffee.web.msm;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -69,14 +68,26 @@ public class TranscoderService {
             + 8; // lastBackupTime
 
     private final SessionAttributesTranscoder _attributesTranscoder;
+    private final ObjectIOStrategy _objectIOStrategy;
 
     /**
      * Creates a new {@link TranscoderService}.
      *
      * @param attributesTranscoder the {@link SessionAttributesTranscoder} strategy to use.
      */
-    public TranscoderService( final SessionAttributesTranscoder attributesTranscoder ) {
+    public TranscoderService( final SessionAttributesTranscoder attributesTranscoder) {
         _attributesTranscoder = attributesTranscoder;
+        _objectIOStrategy = new DefaultObjectIOStrategy();
+    }
+    
+    /**
+     * Creates a new {@link TranscoderService}.
+     *
+     * @param attributesTranscoder the {@link SessionAttributesTranscoder} strategy to use.
+     */
+    public TranscoderService( final SessionAttributesTranscoder attributesTranscoder, ObjectIOStrategy objectIOStrategy) {
+        _attributesTranscoder = attributesTranscoder;
+        _objectIOStrategy = objectIOStrategy;
     }
 
     /**
@@ -186,11 +197,11 @@ public class TranscoderService {
 
     // ---------------------  private/protected helper methods  -------------------
 
-    static byte[] serializeSessionFields( final MemcachedBackupSession session ) {
+    byte[] serializeSessionFields( final MemcachedBackupSession session ) {
         return serializeSessionFields(session, VERSION_2);
     }
 
-    static byte[] serializeSessionFields( final MemcachedBackupSession session, final int version ) {
+    byte[] serializeSessionFields( final MemcachedBackupSession session, final int version ) {
 
         final byte[] idData = serializeId( session.getIdInternal() );
 
@@ -249,7 +260,7 @@ public class TranscoderService {
         return data;
     }
 
-    static DeserializationResult deserializeSessionFields( final byte[] data, final SessionManager manager ) throws InvalidVersionException {
+    DeserializationResult deserializeSessionFields( final byte[] data, final SessionManager manager ) throws InvalidVersionException {
         final MemcachedBackupSession result = manager.newMemcachedBackupSession();
 
         final short version = (short) decodeNum( data, 0, 2 );
@@ -336,15 +347,15 @@ public class TranscoderService {
         }
     }
 
-    private static byte[] serializePrincipal( final Principal principal, final SessionManager manager ) {
+    private byte[] serializePrincipal( final Principal principal, final SessionManager manager ) {
         if(principal == null) {
             return null;
         }
         ByteArrayOutputStream bos = null;
-        ObjectOutputStream oos = null;
+        ObjectOutput oos = null;
         try {
             bos = new ByteArrayOutputStream();
-            oos = new ObjectOutputStream( bos );
+            oos = _objectIOStrategy.createObjectOutput(bos);
             manager.writePrincipal(principal, oos);
             oos.flush();
             return bos.toByteArray();
@@ -356,12 +367,12 @@ public class TranscoderService {
         }
     }
 
-    private static Principal deserializePrincipal( final byte[] data, final SessionManager manager ) {
+    private Principal deserializePrincipal( final byte[] data, final SessionManager manager ) {
         ByteArrayInputStream bis = null;
-        ObjectInputStream ois = null;
+        ObjectInput ois = null;
         try {
             bis = new ByteArrayInputStream( data );
-            ois = new ObjectInputStream( bis );
+            ois = _objectIOStrategy.createObjectInput(bis);
             return manager.readPrincipal( ois );
         } catch ( final IOException e ) {
             throw new IllegalArgumentException( "Could not deserialize principal", e );
@@ -373,17 +384,17 @@ public class TranscoderService {
         }
     }
 
-    private static byte[] serializeSavedRequest( final Object obj ) {
+    private byte[] serializeSavedRequest( final Object obj ) {
         if(obj == null) {
             return null;
         }
 
         final SavedRequest savedRequest = (SavedRequest) obj;
         ByteArrayOutputStream bos = null;
-        ObjectOutputStream oos = null;
+        ObjectOutput oos = null;
         try {
             bos = new ByteArrayOutputStream();
-            oos = new ObjectOutputStream( bos );
+            oos = _objectIOStrategy.createObjectOutput(bos);
             oos.writeObject(savedRequest.getBody());
             oos.writeObject(savedRequest.getContentType());
             // Cookies not cloneable... omit for now - oos.writeObject(newArrayList(savedRequest.getCookies()));
@@ -406,12 +417,12 @@ public class TranscoderService {
     }
 
     @SuppressWarnings("unchecked")
-    private static SavedRequest deserializeSavedRequest( final byte[] data ) {
+    private SavedRequest deserializeSavedRequest( final byte[] data ) {
         ByteArrayInputStream bis = null;
-        ObjectInputStream ois = null;
+        ObjectInput ois = null;
         try {
             bis = new ByteArrayInputStream( data );
-            ois = new ObjectInputStream( bis );
+            ois = _objectIOStrategy.createObjectInput(bis);
 
             final SavedRequest savedRequest = new SavedRequest();
             savedRequest.setBody((ByteChunk) ois.readObject());
@@ -553,24 +564,24 @@ public class TranscoderService {
         return destBeginIndex + src.length;
     }
 
-    private static void closeSilently( final OutputStream os ) {
-        if ( os != null ) {
+    private static void closeSilently( final Closeable closeable ) {
+        if ( closeable != null ) {
             try {
-                os.close();
+            	closeable.close();
             } catch ( final IOException f ) {
                 // fail silently
             }
         }
     }
 
-    private static void closeSilently( final InputStream is ) {
-        if ( is != null ) {
-            try {
-                is.close();
-            } catch ( final IOException f ) {
-                // fail silently
-            }
-        }
+    private static void closeSilently( final AutoCloseable closeable ) {
+      if ( closeable != null ) {
+          try {
+          	closeable.close();
+          } catch ( final Exception f ) {
+              // fail silently
+          }
+      }
     }
 
     /**

--- a/core/src/test/java/de/javakaffee/web/msm/TranscoderServiceTest.java
+++ b/core/src/test/java/de/javakaffee/web/msm/TranscoderServiceTest.java
@@ -110,8 +110,8 @@ public abstract class TranscoderServiceTest {
         final Principal saved = createPrincipal();
         session.setNote(Constants.FORM_PRINCIPAL_NOTE, saved);
 
-        final byte[] data = TranscoderService.serializeSessionFields( session );
-        final MemcachedBackupSession deserialized = TranscoderService.deserializeSessionFields(data, _manager ).getSession();
+        final byte[] data = new TranscoderService(new JavaSerializationTranscoder()).serializeSessionFields( session );
+        final MemcachedBackupSession deserialized = new TranscoderService(new JavaSerializationTranscoder()).deserializeSessionFields(data, _manager ).getSession();
 
         final Principal actual = (Principal) deserialized.getNote(Constants.FORM_PRINCIPAL_NOTE);
         assertNotNull(actual);
@@ -127,8 +127,8 @@ public abstract class TranscoderServiceTest {
         saved.setRequestURI("http://www.foo.org");
         session.setNote(Constants.FORM_REQUEST_NOTE, saved);
 
-        final byte[] data = TranscoderService.serializeSessionFields( session );
-        final MemcachedBackupSession deserialized = TranscoderService.deserializeSessionFields(data, _manager ).getSession();
+        final byte[] data = new TranscoderService(new JavaSerializationTranscoder()).serializeSessionFields( session );
+        final MemcachedBackupSession deserialized = new TranscoderService(new JavaSerializationTranscoder()).deserializeSessionFields(data, _manager ).getSession();
 
         final SavedRequest actual = (SavedRequest) deserialized.getNote(Constants.FORM_REQUEST_NOTE);
         assertNotNull(actual);
@@ -139,8 +139,8 @@ public abstract class TranscoderServiceTest {
     public void testVersionUpgrade() {
         final MemcachedBackupSession session = (MemcachedBackupSession) _manager.createSession( null );
 
-        final byte[] data = TranscoderService.serializeSessionFields( session, TranscoderService.VERSION_1 );
-        final byte[] attributesData = TranscoderService.deserializeSessionFields(data, _manager ).getAttributesData();
+        final byte[] data = new TranscoderService(new JavaSerializationTranscoder()).serializeSessionFields( session, TranscoderService.VERSION_1 );
+        final byte[] attributesData = new TranscoderService(new JavaSerializationTranscoder()).deserializeSessionFields(data, _manager ).getAttributesData();
 
         // we just check that data is read (w/o) bounds issues and no data
         // is left (we just passed data in, w/o added attributesData appended)
@@ -151,8 +151,8 @@ public abstract class TranscoderServiceTest {
     public void testSerializeSessionFields() {
         final MemcachedBackupSession session = (MemcachedBackupSession) _manager.createSession( null );
         session.setLastBackupTime( System.currentTimeMillis() );
-        final byte[] data = TranscoderService.serializeSessionFields( session );
-        final MemcachedBackupSession deserialized = TranscoderService.deserializeSessionFields(data, _manager ).getSession();
+        final byte[] data = new TranscoderService(new JavaSerializationTranscoder()).serializeSessionFields( session );
+        final MemcachedBackupSession deserialized = new TranscoderService(new JavaSerializationTranscoder()).deserializeSessionFields(data, _manager ).getSession();
 
         assertSessionFields( session, deserialized );
     }
@@ -166,8 +166,8 @@ public abstract class TranscoderServiceTest {
 
         session.setLastBackupTime( System.currentTimeMillis() );
 
-        final byte[] data = TranscoderService.serializeSessionFields( session );
-        final MemcachedBackupSession deserialized = TranscoderService.deserializeSessionFields( data, _manager ).getSession();
+        final byte[] data = new TranscoderService(new JavaSerializationTranscoder()).serializeSessionFields( session );
+        final MemcachedBackupSession deserialized = new TranscoderService(new JavaSerializationTranscoder()).deserializeSessionFields( data, _manager ).getSession();
 
         assertSessionFields( session, deserialized );
     }

--- a/flexjson-serializer/pom.xml
+++ b/flexjson-serializer/pom.xml
@@ -3,13 +3,13 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>msm-flexjson-serializer</artifactId>
 	<name>memcached-session-manager flexjson-serializer</name>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>msm-kryo-serializer</artifactId>
 	<name>memcached-session-manager kryo-serializer</name>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-core</artifactId>
-		    <version>[4.2.9.RELEASE,5.0.0.M1)</version>
+		    <version>4.2.9.RELEASE</version>
 			<optional>true</optional>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>memcached-session-manager-project</artifactId>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>memcached-session-manager project</name>
 	<description>

--- a/tomcat6/pom.xml
+++ b/tomcat6/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>memcached-session-manager-tc6</artifactId>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>memcached-session-manager tomcat6</name>
 	<description>The msm tomcat6 specific implementation.</description>

--- a/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -22,8 +22,8 @@ import static de.javakaffee.web.msm.Statistics.StatsType.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.Map;
@@ -1088,12 +1088,12 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     }
 
     @Override
-    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutputStream oos) throws IOException {
+    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutput oos) throws IOException {
         SerializablePrincipal.writePrincipal((GenericPrincipal) principal, oos );
     }
 
     @Override
-    public Principal readPrincipal( final ObjectInputStream ois ) throws ClassNotFoundException, IOException {
+    public Principal readPrincipal( final ObjectInput ois ) throws ClassNotFoundException, IOException {
         return SerializablePrincipal.readPrincipal( ois, getContainer().getRealm() );
     }
 

--- a/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat6/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -1120,4 +1120,11 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return response.getHeaderValues("Set-Cookie");
     }
 
+    public String getObjectIOFactoryClassName() {
+			return _msm.getObjectIOFactoryClassName();
+		}
+
+		public void setObjectIOFactoryClassName(final String objectIOFactoryClassName) {
+			_msm.setObjectIOFactoryClassName(objectIOFactoryClassName);
+		}
 }

--- a/tomcat7/pom.xml
+++ b/tomcat7/pom.xml
@@ -3,12 +3,12 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>memcached-session-manager-tc7</artifactId>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>memcached-session-manager tomcat7</name>
 	<description>The msm tomcat7 specific implementation.</description>

--- a/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -20,8 +20,8 @@ package de.javakaffee.web.msm;
 import static de.javakaffee.web.msm.Statistics.StatsType.*;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Map;
@@ -909,12 +909,12 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     }
 
     @Override
-    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutputStream oos) throws IOException {
+    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutput oos) throws IOException {
         SerializablePrincipal.writePrincipal((GenericPrincipal) principal, oos );
     }
 
     @Override
-    public Principal readPrincipal( final ObjectInputStream ois ) throws ClassNotFoundException, IOException {
+    public Principal readPrincipal( final ObjectInput ois ) throws ClassNotFoundException, IOException {
         return SerializablePrincipal.readPrincipal( ois );
     }
 

--- a/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat7/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -942,4 +942,11 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return result.toArray(new String[result.size()]);
     }
 
+    public String getObjectIOFactoryClassName() {
+			return _msm.getObjectIOFactoryClassName();
+		}
+
+		public void setObjectIOFactoryClassName(final String objectIOFactoryClassName) {
+			_msm.setObjectIOFactoryClassName(objectIOFactoryClassName);
+		}
 }

--- a/tomcat8/pom.xml
+++ b/tomcat8/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>memcached-session-manager-tc8</artifactId>

--- a/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -20,8 +20,8 @@ package de.javakaffee.web.msm;
 import static de.javakaffee.web.msm.Statistics.StatsType.*;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Map;
@@ -886,12 +886,12 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     }
 
     @Override
-    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutputStream oos) throws IOException {
+    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutput oos) throws IOException {
         oos.writeObject(principal);
     }
 
     @Override
-    public Principal readPrincipal( final ObjectInputStream ois ) throws ClassNotFoundException, IOException {
+    public Principal readPrincipal( final ObjectInput ois ) throws ClassNotFoundException, IOException {
         return (Principal) ois.readObject();
     }
 

--- a/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat8/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -917,4 +917,11 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return result.toArray(new String[result.size()]);
     }
 
+    public String getObjectIOFactoryClassName() {
+			return _msm.getObjectIOFactoryClassName();
+		}
+
+		public void setObjectIOFactoryClassName(final String objectIOFactoryClassName) {
+			_msm.setObjectIOFactoryClassName(objectIOFactoryClassName);
+		}
 }

--- a/tomcat9/pom.xml
+++ b/tomcat9/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>memcached-session-manager-tc9</artifactId>

--- a/tomcat9/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat9/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -20,8 +20,8 @@ package de.javakaffee.web.msm;
 import static de.javakaffee.web.msm.Statistics.StatsType.*;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Map;
@@ -886,12 +886,12 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
     }
 
     @Override
-    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutputStream oos) throws IOException {
+    public void writePrincipal( @Nonnull Principal principal, @Nonnull ObjectOutput oos) throws IOException {
         oos.writeObject(principal);
     }
 
     @Override
-    public Principal readPrincipal( final ObjectInputStream ois ) throws ClassNotFoundException, IOException {
+    public Principal readPrincipal( final ObjectInput ois ) throws ClassNotFoundException, IOException {
         return (Principal) ois.readObject();
     }
 

--- a/tomcat9/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
+++ b/tomcat9/src/main/java/de/javakaffee/web/msm/MemcachedBackupSessionManager.java
@@ -917,4 +917,11 @@ public class MemcachedBackupSessionManager extends ManagerBase implements Lifecy
         return result.toArray(new String[result.size()]);
     }
 
+    public String getObjectIOFactoryClassName() {
+			return _msm.getObjectIOFactoryClassName();
+		}
+
+		public void setObjectIOFactoryClassName(final String objectIOFactoryClassName) {
+			_msm.setObjectIOFactoryClassName(objectIOFactoryClassName);
+		}
 }

--- a/xstream-serializer/pom.xml
+++ b/xstream-serializer/pom.xml
@@ -3,13 +3,13 @@
 	<parent>
 		<groupId>de.javakaffee.msm</groupId>
 		<artifactId>memcached-session-manager-project</artifactId>
-		<version>2.3.3-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>de.javakaffee.msm</groupId>
 	<artifactId>msm-xstream-serializer</artifactId>
 	<name>memcached-session-manager xstream-serializer</name>
-	<version>2.3.3-SNAPSHOT</version>
+	<version>2.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<dependencies>


### PR DESCRIPTION
Fix #430 and pave the path for #427 This PR adds two interfaces:

* ObjectIOFactory
* ObjectIOStrategy

The ObjectIOFactory just creates instances of the ObjectIOStrategy. The strategy is invoked when writing/reading anything objects from the the serialized stream that are not the session attributes. 

This PR is implemented in a way so the current behavior is backwards compatible with older versions.

Why is this important: In the current codebase, ordinary ObjectInputStream/ObjectOutputStream are used to serialize various objects. This PR allows you to customize this process.

For full mitigation, both a SessionAttributesTranscoder and an ObjectIOStrategy (and their two factories) that perform serialization class filtering should be implemented.

In our case, we implemented a strategy that uses FST (https://github.com/fstpackage/fst), employs compression(https://github.com/lz4/lz4), encryption / signing / authentication ((https://github.com/martinwithaar/Encryptor4j), and Serialization class filtering (https://docs.oracle.com/en/java/javase/11/core/serialization-filtering1.html). As discussed in #427 this covers an attack vector in which bytecode injection is possible if other checks on the server fail.

We implemented these interfaces and they can be used like this in a `context.xml`:

```
<?xml version="1.0" encoding="UTF-8"?>
<Context>
	<Manager
		className="de.javakaffee.web.msm.MemcachedBackupSessionManager"
		memcachedNodes="${redis.url}"
		sticky="true"
		sessionBackupAsync="true"
		storageKeyPrefix="static:app-name"
		transcoderFactoryClass="com.xxx.sessionmanagement.fst.FstTranscoderFactory"
		objectIOFactoryClassName="com.xxx.sessionmanagement.fst.FstObjectIOFactory"
		requestUriIgnorePattern="(?:^.*\/javax\.faces\.resource\/.*$)|(?:^.*\.(?:ico|png|gif|jpg|css|js)$)|(?:^.*\/(?:404|500).jsf)" />
</Context>
```
